### PR TITLE
feat: add get_peers rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "ckb-types",
  "clap 2.34.0",
  "ctrlc",
+ "dashmap",
  "env_logger",
  "faketime",
  "golomb-coded-set",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ toml = "0.5.8"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 path-clean = "0.1.0"
 rand = "0.8.5"
+dashmap = "4.0"
 faketime = "0.2.1"
 jsonrpc-core = "18.0"
 jsonrpc-derive = "18.0"

--- a/src/protocols/light_client/components/send_block_proof.rs
+++ b/src/protocols/light_client/components/send_block_proof.rs
@@ -386,7 +386,7 @@ impl<'a> SendBlockProofProcess<'a> {
             );
             prove_request.skip_check_tau();
             self.protocol
-                .mut_peers()
+                .peers()
                 .submit_prove_request(self.peer, prove_request);
 
             let message = packed::LightClientMessage::new_builder()
@@ -397,7 +397,7 @@ impl<'a> SendBlockProofProcess<'a> {
             let prove_state =
                 ProveState::new_from_request(prove_request.to_owned(), last_n_headers);
             self.protocol
-                .mut_peers()
+                .peers()
                 .commit_prove_state(self.peer, prove_state);
         }
 

--- a/src/protocols/light_client/components/send_last_state.rs
+++ b/src/protocols/light_client/components/send_last_state.rs
@@ -70,7 +70,7 @@ impl<'a> SendLastStateProcess<'a> {
                 .expect("checked: it should be existed since it's already requested")
                 .get_request()
                 .to_owned();
-            self.protocol.mut_peers().update_timestamp(self.peer, now);
+            self.protocol.peers().update_timestamp(self.peer, now);
 
             content
         } else {
@@ -86,7 +86,7 @@ impl<'a> SendLastStateProcess<'a> {
                 content.clone(),
             );
             self.protocol
-                .mut_peers()
+                .peers()
                 .submit_prove_request(self.peer, prove_request);
 
             content

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -9,7 +9,7 @@ mod status;
 mod synchronizer;
 
 pub(crate) use filter::FilterProtocol;
-pub(crate) use light_client::LightClientProtocol;
+pub(crate) use light_client::{LightClientProtocol, Peers};
 pub(crate) use relayer::{PendingTxs, RelayProtocol};
 pub(crate) use status::{Status, StatusCode};
 pub(crate) use synchronizer::SyncProtocol;


### PR DESCRIPTION
Use `curl` to test the rpc:
```shell
$ echo '{                                                                                                                                                            
    "id": 2,        
    "jsonrpc": "2.0",
    "method": "get_peers",       
    "params": []
}' \
| tr -d '\n' \
| curl -H 'content-type: application/json' -d @- \
http://localhost:9000
```
The Output:
```json
{
  "id": 2,
  "result": [
    {
      "version": "0.104.0-pre (2604b27-dirty 2022-06-13)",
      "sync_state": {
        "requested_best_known_header": null,
        "proved_best_known_header": {
          "version": "0x0",
          "transactions_root": "0xb410ac2c1734c3788f002df9bc78da02fa0a7cb942379c8ad38a1394c0667a05",
          "timestamp": "0x1816117a4f6",
          "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "parent_hash": "0xf6c2f16dd53a0c9d9675f66c85f398f5477270e08d8648ac527c3b1710074782",
          "number": "0x10172",
          "nonce": "0x37d93570476d8fc1bb0969853f69ea68",
          "hash": "0x98280b8d5be5c0d78f0eae758e2495ecc6e691346f52b75f7ab67fbee1a11a59",
          "extra_hash": "0xefac70f3430a2c3bce12fb49e2f89d5fa8afe2eb780e5f9a2df58f7c27acbe25",
          "epoch": "0x3e8038a000041",
          "dao": "0x2a52896d9164dc2ed92a80e8df91230087984160de370c0000c42bc995680007",
          "compact_target": "0x20010000"
        }
      },
      "protocols": [
        {
          "version": "2",
          "id": "0x78"
        },
        {
          "version": "2",
          "id": "0x2"
        },
        {
          "version": "2",
          "id": "0x79"
        },
        {
          "version": "2",
          "id": "0x0"
        },
        {
          "version": "2",
          "id": "0x64"
        },
        {
          "version": "2",
          "id": "0x65"
        },
        {
          "version": "2",
          "id": "0x1"
        },
        {
          "version": "2",
          "id": "0x4"
        }
      ],
      "node_id": "QmWzcco7Q9TegZtbazwzNrfDx1dTd5SeegMCregfScjFZk",
      "connected_duration": "0x53c4",
      "addresses": [
        {
          "score": "0x64",
          "address": "/ip4/127.0.0.1/tcp/8100/p2p/QmWzcco7Q9TegZtbazwzNrfDx1dTd5SeegMCregfScjFZk"
        }
      ]
    }
  ],
  "jsonrpc": "2.0"
}
```