### PR TITLE
fix: skip get genesis block

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -982,8 +982,8 @@ mod tests {
             .header(HeaderBuilder::default().number(0.pack()).build())
             .build();
 
+        storage.init_genesis_block(block0.data());
         storage.update_filter_scripts(HashMap::from([(lock_script1.clone(), 0)]));
-        storage.filter_block(block0.data());
 
         let (mut pre_tx0, mut pre_tx1, mut pre_block) = (tx00, tx01, block0);
         let total_blocks = 255;
@@ -1413,7 +1413,6 @@ mod tests {
             .hash_type(ScriptHashType::Data.into())
             .args(Bytes::from(b"lock_script1".to_vec()).pack())
             .build();
-        storage.update_filter_scripts(HashMap::from([(lock_script1.clone(), 0)]));
 
         let tx00 = TransactionBuilder::default()
             .output(
@@ -1436,7 +1435,8 @@ mod tests {
             .transaction(tx00.clone())
             .header(HeaderBuilder::default().number(0.pack()).build())
             .build();
-        storage.filter_block(block0.data());
+        storage.init_genesis_block(block0.data());
+        storage.update_filter_scripts(HashMap::from([(lock_script1.clone(), 0)]));
 
         let lock_script2 = ScriptBuilder::default()
             .code_hash(H256(rand::random()).pack())


### PR DESCRIPTION
remote code will ban light client when user try to setup a script filter starting from block number 0 and this filter is matching the genesis  block:

```
2022-06-20 13:47:46.378 +09:00 GlobalRt-16 ERROR ckb_sync::synchronizer  receive GetBlocks from SessionId(484), ban 300s for RequestGenesis(417): Request genesis block
2022-06-20 13:47:46.379 +09:00 GlobalRt-16 INFO ckb_network::network  Ban peer "/ip4/127.0.0.1/tcp/53432/p2p/Qmcb8AqckZCfquKnTP6bneX8GudDHghNPaCFNS5oxg3xCi" for 300 seconds, reason: RequestGenesis(417): Request genesis block
```

this pr fixed this bug by filtering the genesis block through local storage and increment block number  to 1.