### PR TITLE
fix: overflow when a 256 bits number multiply a float which less than 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "jsonrpc-http-server",
  "jsonrpc-server-utils",
  "log",
+ "numext-fixed-uint",
  "path-clean",
  "rand 0.6.5",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "7751525
 ckb-merkle-mountain-range = "0.4.0"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }
+numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 anyhow = "1.0.56"
 thiserror = "1.0.30"
 log = "0.4.14"


### PR DESCRIPTION
### Issue

Panic for some values.

For example:

```rust
use ckb_types::{core::RationalU256, u256, U256};
fn main() {
    let x = u256!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
    let x_rational = RationalU256::from_u256(x.clone());
    let numerator = 33u32;
    let denominator = 100u32;
    let y_rational = RationalU256::new(U256::from(numerator), U256::from(denominator));
    let z_rational = x_rational * y_rational; // panicked in this line!
    let z = z_rational.into_u256();
    println!("{:#x} = {:#x} * {}/{}", z, x, numerator, denominator);
}
```