### PR TITLE
refactor: split large functions into several and add unit tests

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         # This target could be increased, but don't decrease it.
-        target: 20%
+        target: 25%
         threshold: 0%
         paths:
         - "src"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "ckb-jsonrpc-types",
  "ckb-merkle-mountain-range 0.4.0",
  "ckb-network",
- "ckb-pow",
  "ckb-resource",
  "ckb-rocksdb",
  "ckb-script",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "7751525
 ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
 ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
 ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
-ckb-pow           = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
 ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
 ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }
 ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "775152587fe141bcb9db45d89f207be194fab073" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[macro_use]
+mod tests;
+
 mod config;
 mod error;
 mod protocols;
@@ -7,9 +11,6 @@ mod subcmds;
 mod types;
 mod utils;
 mod verify;
-
-#[cfg(test)]
-mod tests;
 
 use config::AppConfig;
 

--- a/src/protocols/light_client/sampling.rs
+++ b/src/protocols/light_client/sampling.rs
@@ -12,7 +12,7 @@ const C_FRACTION: f64 = 0.5;
 // Since `log(2**32,10) = 9.63`.
 const RATIO_SCALE_FACTOR: u32 = 1_000_000_000;
 
-struct FlyClientPDF {
+pub(crate) struct FlyClientPDF {
     x_max: f64,
     delta: f64,
 
@@ -38,7 +38,7 @@ pub(crate) fn multiply(uint: &U256, ratio: f64) -> U256 {
 }
 
 impl FlyClientPDF {
-    fn new(
+    pub(crate) fn new(
         delta: f64,
         start_difficulty: U256,
         difficulty_range: U256,
@@ -75,7 +75,7 @@ impl FlyClientPDF {
         }
     }
 
-    fn sampling(&self, samples_count: BlockNumber) -> HashSet<U256> {
+    pub(crate) fn sampling(&self, samples_count: BlockNumber) -> HashSet<U256> {
         let mut difficulties = HashSet::default();
         for _ in 0..samples_count {
             let difficulty = self.random_sample();

--- a/src/protocols/light_client/tests/sampling.rs
+++ b/src/protocols/light_client/tests/sampling.rs
@@ -1,4 +1,65 @@
-use super::super::sampling::{estimate_k, estimate_samples_count};
+use ckb_types::{u256, U256};
+
+use super::super::sampling::{
+    estimate_k, estimate_samples_count, multiply, sample_blocks, FlyClientPDF,
+};
+
+#[test]
+fn test_multiply() {
+    let u256_max = u256!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    let testcases = [
+        ((u256_max.clone(), 1.0 / 2.0), (&u256_max) / 2u32),
+        ((u256_max.clone(), 1.0 / 4.0), (&u256_max) / 4u32),
+        ((u256_max.clone(), 1.0 / 8.0), (&u256_max) / 8u32),
+        ((u256_max.clone(), 1.0 / 16.0), (&u256_max) / 16u32),
+        ((u256_max.clone(), 1.0 / 32.0), (&u256_max) / 32u32),
+        ((u256_max.clone(), 1.0 / 64.0), (&u256_max) / 64u32),
+        ((u256_max.clone(), 1.0 / 128.0), (&u256_max) / 128u32),
+        ((u256_max.clone(), 1.0 / 256.0), (&u256_max) / 256u32),
+        ((u256_max.clone(), 1.0 / 512.0), (&u256_max) / 512u32),
+        (
+            (u256_max.clone(), 0.333333333), // 1/3
+            u256!("0x55555553e6d4575218c8f1177c3fe3e813c77f7d5b16f45aa7b8b89021423c5c"),
+        ),
+        (
+            (u256_max.clone(), 0.047619047), // 1/(3*7)
+            u256!("0xc30c309881ca22ac0509b2b9d9b398a6de035e8cdbcea5f377b9fe71931ddd1"),
+        ),
+        (
+            (u256_max.clone(), 0.000001031), // 1/(3*7*11*13*17*19)
+            u256!("0x114c1c7cfd1a8c371f3fd0136d0906a8aa7273a9b4b395321a9e2abcb0e4"),
+        ),
+        (
+            (u256_max.clone(), 0.000000045), // 1/(3*7*11*13*17*19*23)
+            u256!("0xc14605f3b4ee08dc9d7a4ed09d91cbc4e4f6e524318d96abfe76122afa"),
+        ),
+        ((u256_max, 0.0), u256!("0x1")),
+        ((u256!("0x0"), 0.9), u256!("0x1")),
+    ];
+    for ((uint, ratio), expected) in testcases {
+        let actual = multiply(&uint, ratio);
+        assert_eq!(
+            expected, actual,
+            "multiply {:#x} by {:.9} expect {:#x} but got {:#x}",
+            uint, ratio, expected, actual,
+        );
+    }
+}
+
+#[test]
+fn test_estimate_samples_count_when_blocks_count_le_last_n_blocks() {
+    for last_n_blocks in 1..100 {
+        for blocks_count in 1..=last_n_blocks {
+            let samples_count = estimate_samples_count(blocks_count, last_n_blocks, 1.0);
+            assert_eq!(
+                samples_count, 0,
+                "samples count should be zero when \
+                blocks_count = {} and last_n_blocks = {}",
+                blocks_count, last_n_blocks,
+            );
+        }
+    }
+}
 
 #[test]
 fn test_estimate_k_and_samples_count() {
@@ -64,5 +125,99 @@ fn test_estimate_k_and_samples_count() {
                 sc_expected, sc_actual, l, n, c,
             );
         }
+    }
+}
+
+#[test]
+fn test_fly_client_pdf_samples_should_be_smaller_than_the_boundary() {
+    let delta = 0.1;
+    let start_difficulty = u256!("0x0");
+    let difficulty_range = u256!("0x1000");
+    let difficulty_boundary = u256!("0x5");
+    let pdf = FlyClientPDF::new(
+        delta,
+        start_difficulty,
+        difficulty_range,
+        difficulty_boundary.clone(),
+    );
+    for sample in pdf.sampling(100) {
+        assert!(
+            sample < difficulty_boundary,
+            "sample ({:#x}) should always be smaller than boundary ({:#x})",
+            sample,
+            difficulty_boundary
+        );
+    }
+}
+
+#[test]
+fn test_sample_blocks() {
+    let testcases = [
+        (
+            (1000, u256!("0x10000"), 1010, u256!("0x10100")),
+            (u256!("0x10001"), 0),
+        ),
+        (
+            (1000, u256!("0x10000"), 2000, u256!("0x20000")),
+            (u256!("0x1e666"), 9),
+        ),
+        (
+            (1000, u256!("0x10000"), 10000, u256!("0x100000")),
+            (u256!("0xfd555"), 25),
+        ),
+    ];
+    for (inputs, expected) in testcases {
+        let (start_number, start_difficulty, last_number, last_difficulty) = inputs;
+        let (expected_difficulty_boundary, expected_difficulties_len) = expected;
+        let mut is_passed = false;
+        let mut max = 0;
+        for _ in 0..10 {
+            let (difficulty_boundary, difficulties) = sample_blocks(
+                start_number,
+                &start_difficulty,
+                last_number,
+                &last_difficulty,
+            );
+            assert_eq!(
+                difficulty_boundary,
+                expected_difficulty_boundary,
+                "difficulty boundary expect {:#x} but got {:#x} \
+                when number {} -> {}, difficulty {:#x} -> {:#x}",
+                expected_difficulty_boundary,
+                difficulty_boundary,
+                start_number,
+                last_number,
+                start_difficulty,
+                last_difficulty
+            );
+            if difficulties.len() > expected_difficulties_len {
+                panic!(
+                    "size of difficulties should NOT greater than {} but got {} \
+                    when number {} -> {}, difficulty {:#x} -> {:#x}",
+                    expected_difficulties_len,
+                    difficulties.len(),
+                    start_number,
+                    last_number,
+                    start_difficulty,
+                    last_difficulty
+                );
+            } else if difficulties.len() == expected_difficulties_len {
+                is_passed = true;
+                break;
+            } else if difficulties.len() > max {
+                max = difficulties.len();
+            }
+        }
+        assert!(
+            is_passed,
+            "size of difficulties should be {} in most cases \
+            when number {} -> {}, difficulty {:#x} -> {:#x} but got {}",
+            expected_difficulties_len,
+            start_number,
+            last_number,
+            start_difficulty,
+            last_difficulty,
+            max,
+        );
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,7 @@
+#[macro_use]
+mod prelude;
+
+// The unit tests for modules which are in the root path of this crate.
 mod protocols;
 mod service;
 mod verify;

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -1,0 +1,9 @@
+macro_rules! epoch {
+    ($number:expr, $index:expr, $length:expr) => {
+        ckb_types::core::EpochNumberWithFraction::new($number, $index, $length)
+    };
+    ($tuple:ident) => {{
+        let (number, index, length) = $tuple;
+        ckb_types::core::EpochNumberWithFraction::new(number, index, length)
+    }};
+}


### PR DESCRIPTION
### Issue

There are lots of duplicate code between `send_block_proof.rs` and `send_block_samples.rs`.

Merge these code into several functions and add unit tests for them.