### PR TITLE
chore(deps): bump ckb to the latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 name = "ckb-app-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-build-info",
  "ckb-chain-spec",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "ckb-async-runtime"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-logger",
  "ckb-spawn",
@@ -308,12 +308,12 @@ dependencies = [
 [[package]]
 name = "ckb-build-info"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 
 [[package]]
 name = "ckb-chain-spec"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-constant",
  "ckb-crypto",
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 name = "ckb-channel"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -342,12 +342,12 @@ dependencies = [
 [[package]]
 name = "ckb-constant"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 
 [[package]]
 name = "ckb-crypto"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "ckb-dao"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "ckb-dao-utils"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "ckb-error"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash-core"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "faster-hex",
  "serde",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash-macros"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "ckb-hash"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "ckb-jsonrpc-types"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-types",
  "faster-hex",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "log",
 ]
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "serde",
 ]
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "ckb-metrics"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "opentelemetry",
 ]
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "ckb-metrics-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "serde",
 ]
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "ckb-network"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "bloom-filters",
  "ckb-app-config",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity-core"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "serde",
 ]
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity-macros"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "ckb-pow"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "ckb-rational"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "ckb-resource"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "ckb-script"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -657,12 +657,12 @@ dependencies = [
 [[package]]
 name = "ckb-spawn"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 
 [[package]]
 name = "ckb-stop-handler"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-channel",
  "ckb-logger",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "ckb-traits"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-types",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "ckb-types"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "ckb-util"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "linked-hash-map",
  "once_cell",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "ckb-verification"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "ckb-verification-traits"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=c21e03765f1f3928fe6f1cba10df2d24b77c9d16#c21e03765f1f3928fe6f1cba10df2d24b77c9d16"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "bitflags",
  "ckb-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "1ed5e24cc97b34a04540e2092b5884391eeeea8e" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "c21e03765f1f3928fe6f1cba10df2d24b77c9d16" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "78f48d4fbf600e46414e7fb0b410e9d058200bad" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "02d9688efaa5db8656f63226ee8c8a59eb898998" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "d7efaf9d5120edb1285d0904e63ec3d92f92c462" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "dc9b23bf232765c65fdf39d687ea7a5e1cc199f8" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mutable_key_type)]
+
 #[cfg(test)]
 #[macro_use]
 mod tests;

--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -183,7 +183,7 @@ impl CKBProtocolHandler for FilterProtocol {
                     .peers
                     .get_peers_which_are_proved()
                     .iter()
-                    .max_by_key(|(_, prove_state)| prove_state.get_total_difficulty())
+                    .max_by_key(|(_, prove_state)| prove_state.get_last_header().total_difficulty())
                 {
                     let start_number = self.pending_peer.min_filtered_block_number() + 1;
                     let prove_state_number = prove_state.get_last_header().header().number();

--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -91,7 +91,7 @@ impl<'a> BlockFiltersProcess<'a> {
             );
             if possible_match_blocks_len != 0 {
                 if peer_state.get_block_proof_request().is_some() {
-                    warn!("peer {} has an inflight GetBlockProof request", self.peer);
+                    warn!("peer {} has an inflight GetBlocksProof request", self.peer);
                 } else {
                     // if the only matched block is the prove state block, then request block data directly
                     possible_match_blocks
@@ -125,9 +125,9 @@ impl<'a> BlockFiltersProcess<'a> {
                             trace!("already sent block proof request to peer: {}", self.peer);
                         } else {
                             trace!("send block proof request to peer: {}", self.peer);
-                            let content = packed::GetBlockProof::new_builder()
+                            let content = packed::GetBlocksProof::new_builder()
                                 .block_hashes(possible_match_blocks.pack())
-                                .tip_hash(prove_state_block_hash)
+                                .last_hash(prove_state_block_hash)
                                 .build();
                             let message = packed::LightClientMessage::new_builder()
                                 .set(content.clone())

--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -90,11 +90,8 @@ impl<'a> BlockFiltersProcess<'a> {
                 possible_match_blocks_len
             );
             if possible_match_blocks_len != 0 {
-                if !peer_state.can_insert_block_proof_request() {
-                    warn!(
-                        "peer {} has too many inflight GetBlockProof requests",
-                        self.peer
-                    );
+                if peer_state.get_block_proof_request().is_some() {
+                    warn!("peer {} has an inflight GetBlockProof request", self.peer);
                 } else {
                     // if the only matched block is the prove state block, then request block data directly
                     possible_match_blocks
@@ -117,15 +114,21 @@ impl<'a> BlockFiltersProcess<'a> {
                         }
                     } else {
                         let fetch_tip = possible_match_blocks_len != possible_match_blocks.len();
-                        let content = packed::GetBlockProof::new_builder()
-                            .block_hashes(possible_match_blocks.pack())
-                            .tip_hash(prove_state_block_hash)
-                            .build();
 
-                        if peer_state.contains_block_proof_request(&content) {
-                            trace!("already sent block proof request to peer: {}", self.peer,);
+                        if peer_state
+                            .get_block_proof_request()
+                            .map(|req| {
+                                req.is_same_as(&prove_state_block_hash, &possible_match_blocks)
+                            })
+                            .unwrap_or(false)
+                        {
+                            trace!("already sent block proof request to peer: {}", self.peer);
                         } else {
-                            trace!("send block proof request to peer: {}", self.peer,);
+                            trace!("send block proof request to peer: {}", self.peer);
+                            let content = packed::GetBlockProof::new_builder()
+                                .block_hashes(possible_match_blocks.pack())
+                                .tip_hash(prove_state_block_hash)
+                                .build();
                             let message = packed::LightClientMessage::new_builder()
                                 .set(content.clone())
                                 .build();
@@ -140,9 +143,10 @@ impl<'a> BlockFiltersProcess<'a> {
                                 error!("{}", error_message);
                                 return StatusCode::Network.with_context(error_message);
                             } else {
-                                self.filter
-                                    .peers
-                                    .insert_block_proof_request(self.peer, content, fetch_tip);
+                                self.filter.peers.update_block_proof_request(
+                                    self.peer,
+                                    Some((content, fetch_tip)),
+                                );
                             }
                         }
                     }

--- a/src/protocols/light_client/components/mod.rs
+++ b/src/protocols/light_client/components/mod.rs
@@ -1,10 +1,10 @@
-mod send_block_proof;
-mod send_block_samples;
+mod send_blocks_proof;
 mod send_last_state;
+mod send_last_state_proof;
 
 #[cfg(test)]
 mod tests;
 
-pub(crate) use send_block_proof::SendBlockProofProcess;
-pub(crate) use send_block_samples::SendBlockSamplesProcess;
+pub(crate) use send_blocks_proof::SendBlocksProofProcess;
 pub(crate) use send_last_state::SendLastStateProcess;
+pub(crate) use send_last_state_proof::{verify_mmr_proof, SendLastStateProofProcess};

--- a/src/protocols/light_client/components/send_block_proof.rs
+++ b/src/protocols/light_client/components/send_block_proof.rs
@@ -41,15 +41,11 @@ impl<'a> SendBlockProofProcess<'a> {
             return StatusCode::PeerIsNotOnProcess.into();
         };
 
-        let received_last_header: VerifiableHeader = self.message.tip_header().to_entity().into();
-        let received_chain_root = self.message.root().to_entity();
+        let last_header: VerifiableHeader = self.message.tip_header().to_entity().into();
 
+        // Update the last state if the response contains a new one.
         if self.message.proof().is_empty() {
-            return_if_failed!(self.protocol.process_last_state(
-                self.peer,
-                received_last_header,
-                received_chain_root,
-            ));
+            return_if_failed!(self.protocol.process_last_state(self.peer, last_header));
             self.protocol
                 .peers()
                 .update_block_proof_request(self.peer, None);
@@ -62,58 +58,57 @@ impl<'a> SendBlockProofProcess<'a> {
             .iter()
             .map(|header| header.to_entity().into_view())
             .collect();
-        let received_block_hashes = headers
-            .iter()
-            .map(|header| header.hash())
-            .collect::<Vec<_>>();
 
-        if !original_request.is_same_as(
-            &received_last_header.header().hash(),
-            &received_block_hashes,
-        ) {
-            error!("peer {} send an unknown proof", self.peer);
-            return StatusCode::InvalidSendBlockProof.into();
+        // Check if the response is match the request.
+        {
+            let received_block_hashes = headers
+                .iter()
+                .map(|header| header.hash())
+                .collect::<Vec<_>>();
+            if !original_request.is_same_as(&last_header.header().hash(), &received_block_hashes) {
+                error!("peer {} send an unknown proof", self.peer);
+                return StatusCode::InvalidSendBlockProof.into();
+            }
         }
 
-        // Check PoW
-        return_if_failed!(self
-            .protocol
-            .check_pow_for_headers(headers.iter().chain(Some(received_last_header.header()))));
+        // Check PoW for blocks
+        return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
         // Verify the proof
         return_if_failed!(verify_mmr_proof(
             self.protocol.mmr_activated_epoch(),
-            &received_last_header,
-            self.message.root().to_entity(),
+            &last_header,
             self.message.proof(),
             headers.iter(),
         ));
 
-        // Send get blocks
-        let block_hashes: Vec<packed::Byte32> = headers
-            .iter()
-            .chain(if original_request.if_fetch_tip() {
-                Some(received_last_header.header())
-            } else {
-                None
-            })
-            .map(|header| header.hash())
-            .collect();
+        // Get blocks
+        {
+            let block_hashes: Vec<packed::Byte32> = headers
+                .iter()
+                .chain(if original_request.if_fetch_tip() {
+                    Some(last_header.header())
+                } else {
+                    None
+                })
+                .map(|header| header.hash())
+                .collect();
 
-        for hashes in block_hashes.chunks(INIT_BLOCKS_IN_TRANSIT_PER_PEER) {
-            let content = packed::GetBlocks::new_builder()
-                .block_hashes(hashes.to_vec().pack())
-                .build();
-            let message = packed::SyncMessage::new_builder().set(content).build();
+            for hashes in block_hashes.chunks(INIT_BLOCKS_IN_TRANSIT_PER_PEER) {
+                let content = packed::GetBlocks::new_builder()
+                    .block_hashes(hashes.to_vec().pack())
+                    .build();
+                let message = packed::SyncMessage::new_builder().set(content).build();
 
-            if let Err(err) = self.nc.send_message(
-                SupportProtocols::Sync.protocol_id(),
-                self.peer,
-                message.as_bytes(),
-            ) {
-                let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
-                error!("{}", error_message);
-                return StatusCode::Network.with_context(error_message);
+                if let Err(err) = self.nc.send_message(
+                    SupportProtocols::Sync.protocol_id(),
+                    self.peer,
+                    message.as_bytes(),
+                ) {
+                    let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
+                    error!("{}", error_message);
+                    return StatusCode::Network.with_context(error_message);
+                }
             }
         }
 

--- a/src/protocols/light_client/components/send_block_proof.rs
+++ b/src/protocols/light_client/components/send_block_proof.rs
@@ -66,23 +66,18 @@ impl<'a> SendBlockProofProcess<'a> {
         }
 
         // Check PoW
-        if let Err(status) = self
+        return_if_failed!(self
             .protocol
-            .check_pow_for_headers(headers.iter().chain(Some(tip_header.header())))
-        {
-            return status;
-        }
+            .check_pow_for_headers(headers.iter().chain(Some(tip_header.header()))));
 
         // Verify the proof
-        if let Err(status) = verify_mmr_proof(
+        return_if_failed!(verify_mmr_proof(
             self.protocol.mmr_activated_epoch(),
             &tip_header,
             self.message.root().to_entity(),
             self.message.proof(),
             headers.iter(),
-        ) {
-            return status;
-        }
+        ));
 
         // Send get blocks
         let block_hashes: Vec<packed::Byte32> = headers

--- a/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/src/protocols/light_client/components/send_blocks_proof.rs
@@ -5,19 +5,19 @@ use log::error;
 
 use super::{
     super::{LightClientProtocol, Status, StatusCode},
-    send_block_samples::verify_mmr_proof,
+    verify_mmr_proof,
 };
 
-pub(crate) struct SendBlockProofProcess<'a> {
-    message: packed::SendBlockProofReader<'a>,
+pub(crate) struct SendBlocksProofProcess<'a> {
+    message: packed::SendBlocksProofReader<'a>,
     protocol: &'a mut LightClientProtocol,
     peer: PeerIndex,
     nc: &'a dyn CKBProtocolContext,
 }
 
-impl<'a> SendBlockProofProcess<'a> {
+impl<'a> SendBlocksProofProcess<'a> {
     pub(crate) fn new(
-        message: packed::SendBlockProofReader<'a>,
+        message: packed::SendBlocksProofReader<'a>,
         protocol: &'a mut LightClientProtocol,
         peer: PeerIndex,
         nc: &'a dyn CKBProtocolContext,
@@ -41,7 +41,7 @@ impl<'a> SendBlockProofProcess<'a> {
             return StatusCode::PeerIsNotOnProcess.into();
         };
 
-        let last_header: VerifiableHeader = self.message.tip_header().to_entity().into();
+        let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
 
         // Update the last state if the response contains a new one.
         if self.message.proof().is_empty() {
@@ -67,7 +67,7 @@ impl<'a> SendBlockProofProcess<'a> {
                 .collect::<Vec<_>>();
             if !original_request.is_same_as(&last_header.header().hash(), &received_block_hashes) {
                 error!("peer {} send an unknown proof", self.peer);
-                return StatusCode::InvalidSendBlockProof.into();
+                return StatusCode::InvalidSendBlocksProof.into();
             }
         }
 

--- a/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/src/protocols/light_client/components/send_blocks_proof.rs
@@ -67,7 +67,7 @@ impl<'a> SendBlocksProofProcess<'a> {
                 .collect::<Vec<_>>();
             if !original_request.is_same_as(&last_header.header().hash(), &received_block_hashes) {
                 error!("peer {} send an unknown proof", self.peer);
-                return StatusCode::InvalidSendBlocksProof.into();
+                return StatusCode::UnexpectedRequest.into();
             }
         }
 

--- a/src/protocols/light_client/components/send_last_state.rs
+++ b/src/protocols/light_client/components/send_last_state.rs
@@ -28,7 +28,7 @@ impl<'a> SendLastStateProcess<'a> {
     pub(crate) fn execute(self) -> Status {
         let peer_state = return_if_failed!(self.protocol.get_peer_state(&self.peer));
 
-        let last_header: VerifiableHeader = self.message.tip_header().to_entity().into();
+        let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
         return_if_failed!(self.protocol.check_verifiable_header(&last_header));
 
         let last_state = LastState::new(last_header);

--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -559,7 +559,7 @@ pub(crate) fn check_if_response_is_matched(
                     total_difficulty_lhs,
                     total_difficulty_rhs,
                 );
-                return Err(StatusCode::InvalidTotalDifficultyForSamples.into());
+                return Err(StatusCode::InvalidSamples.into());
             }
         }
 
@@ -579,7 +579,7 @@ pub(crate) fn check_if_response_is_matched(
                     next_difficulty,
                     first_last_n_total_difficulty
                 );
-                return Err(StatusCode::InvalidTotalDifficultyForSamples.into());
+                return Err(StatusCode::InvalidSamples.into());
             }
         }
     }
@@ -780,7 +780,7 @@ pub(crate) fn verify_mmr_proof<'a, T: Iterator<Item = &'a HeaderView>>(
             Ok(tmp) => tmp,
             Err(err) => {
                 let errmsg = format!("failed to verify all digest since {}", err);
-                return Err(StatusCode::FailedToVerifyTheProof.with_context(errmsg));
+                return Err(StatusCode::InvalidProof.with_context(errmsg));
             }
         }
     };
@@ -788,14 +788,14 @@ pub(crate) fn verify_mmr_proof<'a, T: Iterator<Item = &'a HeaderView>>(
         Ok(verify_result) => verify_result,
         Err(err) => {
             let errmsg = format!("failed to verify the proof since {}", err);
-            return Err(StatusCode::FailedToVerifyTheProof.with_context(errmsg));
+            return Err(StatusCode::InvalidProof.with_context(errmsg));
         }
     };
     if verify_result {
         trace!("passed: verify mmr proof");
     } else {
         let errmsg = "failed to verify the mmr proof since the result is false";
-        return Err(StatusCode::FailedToVerifyTheProof.with_context(errmsg));
+        return Err(StatusCode::InvalidProof.with_context(errmsg));
     }
     let check_extra_hash_result = last_header.is_valid(mmr_activated_epoch);
     if check_extra_hash_result {
@@ -810,7 +810,7 @@ pub(crate) fn verify_mmr_proof<'a, T: Iterator<Item = &'a HeaderView>>(
             last_header.header().number(),
             last_header.header().hash(),
         );
-        return Err(StatusCode::FailedToVerifyTheProof.with_context(errmsg));
+        return Err(StatusCode::InvalidProof.with_context(errmsg));
     };
 
     Ok(())

--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -20,16 +20,16 @@ use super::super::{
 };
 use crate::protocols::LAST_N_BLOCKS;
 
-pub(crate) struct SendBlockSamplesProcess<'a> {
-    message: packed::SendBlockSamplesReader<'a>,
+pub(crate) struct SendLastStateProofProcess<'a> {
+    message: packed::SendLastStateProofReader<'a>,
     protocol: &'a mut LightClientProtocol,
     peer: PeerIndex,
     nc: &'a dyn CKBProtocolContext,
 }
 
-impl<'a> SendBlockSamplesProcess<'a> {
+impl<'a> SendLastStateProofProcess<'a> {
     pub(crate) fn new(
-        message: packed::SendBlockSamplesReader<'a>,
+        message: packed::SendLastStateProofReader<'a>,
         protocol: &'a mut LightClientProtocol,
         peer: PeerIndex,
         nc: &'a dyn CKBProtocolContext,
@@ -474,7 +474,7 @@ impl EpochDifficultyTrendDetails {
 // - Check the difficulties.
 pub(crate) fn check_if_response_is_matched(
     mmr_activated_epoch: EpochNumber,
-    prev_request: &packed::GetBlockSamples,
+    prev_request: &packed::GetLastStateProof,
     sampled_headers: &[VerifiableHeader],
     last_n_headers: packed::VerifiableHeaderVecReader,
 ) -> Result<(), Status> {

--- a/src/protocols/light_client/components/tests/mod.rs
+++ b/src/protocols/light_client/components/tests/mod.rs
@@ -1,1 +1,1 @@
-mod send_block_samples;
+mod send_last_state_proof;

--- a/src/protocols/light_client/components/tests/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/tests/send_last_state_proof.rs
@@ -4,7 +4,7 @@ use ckb_types::{
     {u256, U256},
 };
 
-use super::super::send_block_samples::{
+use super::super::send_last_state_proof::{
     verify_tau, verify_total_difficulty, EpochDifficultyTrend, EstimatedLimit,
 };
 

--- a/src/protocols/light_client/constant.rs
+++ b/src/protocols/light_client/constant.rs
@@ -2,5 +2,3 @@ use std::time::Duration;
 
 pub const REFRESH_PEERS_TOKEN: u64 = 0;
 pub const REFRESH_PEERS_DURATION: Duration = Duration::from_secs(60);
-pub const CHECK_GET_BLOCK_PROOFS_TOKEN: u64 = 1;
-pub const CHECK_GET_BLOCK_PROOFS_DURATION: Duration = Duration::from_secs(10);

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -129,11 +129,11 @@ impl LightClientProtocol {
             packed::LightClientMessageUnionReader::SendLastState(reader) => {
                 components::SendLastStateProcess::new(reader, self, peer, nc).execute()
             }
-            packed::LightClientMessageUnionReader::SendBlockSamples(reader) => {
-                components::SendBlockSamplesProcess::new(reader, self, peer, nc).execute()
+            packed::LightClientMessageUnionReader::SendLastStateProof(reader) => {
+                components::SendLastStateProofProcess::new(reader, self, peer, nc).execute()
             }
-            packed::LightClientMessageUnionReader::SendBlockProof(reader) => {
-                components::SendBlockProofProcess::new(reader, self, peer, nc).execute()
+            packed::LightClientMessageUnionReader::SendBlocksProof(reader) => {
+                components::SendBlocksProofProcess::new(reader, self, peer, nc).execute()
             }
             _ => StatusCode::UnexpectedProtocolMessage.into(),
         }
@@ -359,7 +359,7 @@ impl LightClientProtocol {
         &self,
         peer_state: &PeerState,
         last_header: &VerifiableHeader,
-    ) -> Option<packed::GetBlockSamples> {
+    ) -> Option<packed::GetLastStateProof> {
         let last_n_blocks = LAST_N_BLOCKS;
         let last_number = last_header.header().number();
         let last_total_difficulty = last_header.total_difficulty();
@@ -395,7 +395,7 @@ impl LightClientProtocol {
         if start_total_difficulty > last_total_difficulty || start_number >= last_number {
             return None;
         }
-        let builder = packed::GetBlockSamples::new_builder()
+        let builder = packed::GetLastStateProof::new_builder()
             .last_hash(last_header.header().hash())
             .start_hash(start_hash)
             .start_number(start_number.pack())

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -193,6 +193,25 @@ impl LightClientProtocol {
         }
     }
 
+    pub(crate) fn check_chain_root_for_headers<'a, T: Iterator<Item = &'a VerifiableHeader>>(
+        &self,
+        headers: T,
+    ) -> Result<(), Status> {
+        let mmr_activated_epoch = self.mmr_activated_epoch();
+        for header in headers {
+            if !header.is_valid(mmr_activated_epoch) {
+                let header = header.header();
+                let errmsg = format!(
+                    "failed to verify chain root for block#{}, hash: {:#x}",
+                    header.number(),
+                    header.hash()
+                );
+                return Err(StatusCode::InvalidChainRootForSamples.with_context(errmsg));
+            }
+        }
+        Ok(())
+    }
+
     fn check_verifiable_header(&self, verifiable_header: &VerifiableHeader) -> Result<(), Status> {
         let header = verifiable_header.header();
         // Check PoW

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -206,7 +206,7 @@ impl LightClientProtocol {
                     header.number(),
                     header.hash()
                 );
-                return Err(StatusCode::InvalidChainRootForSamples.with_context(errmsg));
+                return Err(StatusCode::InvalidChainRoot.with_context(errmsg));
             }
         }
         Ok(())
@@ -230,7 +230,7 @@ impl LightClientProtocol {
                 header.number(),
                 header.hash()
             );
-            return Err(StatusCode::InvalidLastState.with_context(errmsg));
+            return Err(StatusCode::InvalidChainRoot.with_context(errmsg));
         }
         Ok(())
     }

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -39,7 +39,7 @@ pub(crate) struct PeerState {
 #[derive(Clone)]
 pub(crate) struct ProveRequest {
     last_state: LastState,
-    content: packed::GetBlockSamples,
+    content: packed::GetLastStateProof,
     skip_check_tau: bool,
 }
 
@@ -52,7 +52,7 @@ pub(crate) struct ProveState {
 
 #[derive(Clone)]
 pub(crate) struct BlockProofRequest {
-    content: packed::GetBlockProof,
+    content: packed::GetBlocksProof,
     // A flag indicates that corresponding tip block should be fetched or not.
     fetch_tip: bool,
     when_sent: u64,
@@ -75,7 +75,7 @@ impl LastState {
 }
 
 impl ProveRequest {
-    pub(crate) fn new(last_state: LastState, content: packed::GetBlockSamples) -> Self {
+    pub(crate) fn new(last_state: LastState, content: packed::GetLastStateProof) -> Self {
         Self {
             last_state,
             content,
@@ -91,7 +91,7 @@ impl ProveRequest {
         if_verifiable_headers_are_same(self.get_last_header(), another)
     }
 
-    pub(crate) fn get_content(&self) -> &packed::GetBlockSamples {
+    pub(crate) fn get_content(&self) -> &packed::GetLastStateProof {
         &self.content
     }
 
@@ -154,7 +154,7 @@ impl ProveState {
 }
 
 impl BlockProofRequest {
-    fn new(content: packed::GetBlockProof, fetch_tip: bool, when_sent: u64) -> Self {
+    fn new(content: packed::GetBlocksProof, fetch_tip: bool, when_sent: u64) -> Self {
         Self {
             content,
             fetch_tip,
@@ -167,9 +167,9 @@ impl BlockProofRequest {
         last_hash: &packed::Byte32,
         block_hashes: &[packed::Byte32],
     ) -> bool {
-        let content = packed::GetBlockProof::new_builder()
+        let content = packed::GetBlocksProof::new_builder()
             .block_hashes(block_hashes.to_vec().pack())
-            .tip_hash(last_hash.to_owned())
+            .last_hash(last_hash.to_owned())
             .build();
         self.content.as_slice() == content.as_slice()
     }
@@ -294,7 +294,7 @@ impl Peers {
     pub(crate) fn update_block_proof_request(
         &self,
         index: PeerIndex,
-        request: Option<(packed::GetBlockProof, bool)>,
+        request: Option<(packed::GetBlocksProof, bool)>,
     ) {
         if let Some(mut peer) = self.inner.get_mut(&index) {
             peer.state

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -22,9 +22,7 @@ pub(crate) use status::{Status, StatusCode};
 pub(crate) use synchronizer::SyncProtocol;
 
 pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
-// if GetBlockProof requests greater than 64, ban the peer
-pub const MAX_BLOCK_RPOOF_REQUESTS: usize = 64;
-// if have GetBlockProof request last more than 60 seconds, ban the peer
-pub const GET_BLOCK_PROOF_TIMEOUT: u64 = 60 * 1000;
+// Ban a peer if it reach any timeout.
+pub const MESSAGE_TIMEOUT: u64 = 60 * 1000;
 
 pub const LAST_N_BLOCKS: BlockNumber = 100;

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -2,10 +2,12 @@ use std::time::Duration;
 
 use ckb_types::core::BlockNumber;
 
+#[macro_use]
+mod status;
+
 mod filter;
 mod light_client;
 mod relayer;
-mod status;
 mod synchronizer;
 
 #[cfg(test)]

--- a/src/protocols/status.rs
+++ b/src/protocols/status.rs
@@ -46,8 +46,8 @@ pub enum StatusCode {
     InvalidParentHash = 428,
     /// Failed to verify the proof.
     FailedToVerifyTheProof = 429,
-    /// Invalid SendBlockProof response (not match the GetBlockProof request)
-    InvalidSendBlockProof = 430,
+    /// Invalid SendBlocksProof response (not match the GetBlocksProof request)
+    InvalidSendBlocksProof = 430,
 
     /// Throws an internal error.
     InternalError = 500,

--- a/src/protocols/status.rs
+++ b/src/protocols/status.rs
@@ -28,26 +28,30 @@ pub enum StatusCode {
     /// The last state sent from server is invalid.
     InvalidLastState = 412,
 
-    /// Receives a proof but the peer isn't waiting for a proof.
+    /// Receives a response but the peer isn't waiting for a response.
     PeerIsNotOnProcess = 421,
-    /// Failed to verify chain roots for samples.
-    InvalidChainRootForSamples = 422,
-    /// Failed to verify total difficulty for samples.
-    InvalidTotalDifficultyForSamples = 423,
-    /// Failed to verify the compact target.
-    InvalidCompactTarget = 424,
-    /// Failed to verify the total difficulty.
-    InvalidTotalDifficulty = 425,
+    /// The response is not match our request.
+    UnexpectedRequest = 422,
+
+    // Common errors for all verifications.
+    /// Failed to verify chain root.
+    InvalidChainRoot = 431,
     /// Failed to verify the pow.
-    InvalidNonce = 426,
-    /// The last header number in reorg_last_n_headers is wrong
-    InvalidReorgHeaders = 427,
+    InvalidNonce = 432,
+    /// Failed to verify the compact target.
+    InvalidCompactTarget = 433,
+    /// Failed to verify the total difficulty.
+    InvalidTotalDifficulty = 434,
     /// Failed to verify the parent hash.
-    InvalidParentHash = 428,
+    InvalidParentHash = 435,
     /// Failed to verify the proof.
-    FailedToVerifyTheProof = 429,
-    /// Invalid SendBlocksProof response (not match the GetBlocksProof request)
-    InvalidSendBlocksProof = 430,
+    InvalidProof = 439,
+
+    // Specific errors for specific messages.
+    /// Samples for a last state proof is invalid.
+    InvalidSamples = 451,
+    /// Reorg headers for a last state proof is invalid.
+    InvalidReorgHeaders = 452,
 
     /// Throws an internal error.
     InternalError = 500,

--- a/src/protocols/status.rs
+++ b/src/protocols/status.rs
@@ -23,8 +23,10 @@ pub enum StatusCode {
     /// Unexpected light-client protocol message.
     UnexpectedProtocolMessage = 401,
 
+    /// The peer state is not found.
+    PeerStateIsNotFound = 411,
     /// The last state sent from server is invalid.
-    InvalidLastState = 411,
+    InvalidLastState = 412,
 
     /// Receives a proof but the peer isn't waiting for a proof.
     PeerIsNotOnProcess = 421,
@@ -58,6 +60,15 @@ pub enum StatusCode {
 pub struct Status {
     code: StatusCode,
     context: Option<String>,
+}
+
+macro_rules! return_if_failed {
+    ($result:expr) => {
+        match $result {
+            Ok(data) => data,
+            Err(status) => return status,
+        }
+    };
 }
 
 impl PartialEq for Status {

--- a/src/service.rs
+++ b/src/service.rs
@@ -243,7 +243,6 @@ pub struct NetRpcImpl {
     peers: Arc<Peers>,
 }
 
-#[allow(clippy::mutable_key_type)]
 impl BlockFilterRpc for BlockFilterRpcImpl {
     fn set_scripts(&self, scripts: Vec<ScriptStatus>) -> Result<()> {
         let scripts = scripts

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -29,7 +29,6 @@ pub struct Storage {
     pub(crate) db: Arc<DB>,
 }
 
-#[allow(clippy::mutable_key_type)]
 impl Storage {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         let db = Arc::new(DB::open_default(path).expect("Failed to open rocksdb"));

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -12,7 +12,7 @@ use ckb_types::{
     packed::{self, Script},
     prelude::*,
     utilities::merkle_mountain_range::VerifiableHeader,
-    H256, U256,
+    H256,
 };
 
 use crate::protocols::{
@@ -64,11 +64,9 @@ async fn test_block_filter_ignore_start_number() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -120,11 +118,9 @@ async fn test_block_filter_empty_filters() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -176,11 +172,9 @@ async fn test_block_filter_invalid_filters_count() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -237,11 +231,9 @@ async fn test_block_filter_start_number_greater_then_proved_number() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -295,11 +287,9 @@ async fn test_block_filter_ok_with_blocks_not_matched() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -372,11 +362,9 @@ async fn test_block_filter_ok_with_blocks_matched() {
             .number((proved_number).pack())
             .build();
         let prove_state_block_hash = header.hash();
-        let tip_header = VerifiableHeader::new(header, Default::default(), None);
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let tip_header =
+            VerifiableHeader::new(header, Default::default(), None, Default::default());
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -473,11 +461,9 @@ async fn test_block_filter_notify_ask_filters() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -552,11 +538,9 @@ async fn test_block_filter_notify_not_reach_ask() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());
@@ -597,11 +581,9 @@ async fn test_block_filter_notify_proved_number_not_big_enough() {
                 .build(),
             Default::default(),
             None,
+            Default::default(),
         );
-        let last_state = LastState {
-            tip_header,
-            total_difficulty: U256::one(),
-        };
+        let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
             ProveState::new_from_request(request, Default::default(), Default::default());

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -404,9 +404,9 @@ async fn test_block_filter_ok_with_blocks_matched() {
     assert!(nc.banned_peers.borrow().is_empty());
 
     let get_block_proof_message = {
-        let content = packed::GetBlockProof::new_builder()
+        let content = packed::GetBlocksProof::new_builder()
             .block_hashes(vec![block_hash.pack()].pack())
-            .tip_hash(prove_state_block_hash)
+            .last_hash(prove_state_block_hash)
             .build();
         packed::LightClientMessage::new_builder()
             .set(content.clone())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -63,7 +63,6 @@ pub fn verify_tx(
         .verify(consensus.max_block_cycles())
 }
 
-#[allow(clippy::mutable_key_type)]
 fn resolve_tx(
     swl: &StorageWithLastHeaders,
     transaction: TransactionView,


### PR DESCRIPTION
### Changes

- feat: subscribe the chain state and prove it in a simpler way

  If the chain sent a new verifiable header to the client, which is the child block of a verified block in client-side, and it could be verified for its nonce and its chain root, then we can trust it.

- feat: synchronize the last state if the server has a fork chain

  All components, which are used to ask for a proof, will send the new last state to the client when the last state in client-side is not on their current chain.

- refactor: a verifiable header always contains its parent chain root

- refactor: standardize light client protocol message names and field names

- refactor: merge all groups of headers in last state proof into one

  Merge `reorg_last_n_headers`, `sampled_headers` and `last_n_headers` into one.

- refactor: classify status codes

  The status codes will be used for unit tests.
  
Ref: nervosnetwork/ckb#3558