### PR TITLE
fix: skip asking proof if no updates for the last state

### DIFF
--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ckb_chain_spec::consensus::Consensus;
 use ckb_network::{async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_types::{
-    core::{EpochNumber, HeaderView},
+    core::{BlockNumber, EpochNumber, HeaderView},
     packed,
     prelude::*,
     utilities::merkle_mountain_range::VerifiableHeader,
@@ -319,12 +319,13 @@ impl LightClientProtocol {
         }
     }
 
-    fn build_prove_request_content(
+    pub(crate) fn build_prove_request_content(
         &self,
         peer_state: &PeerState,
         last_header: &VerifiableHeader,
         last_total_difficulty: &U256,
     ) -> Option<packed::GetBlockSamples> {
+        let last_number = last_header.header().number();
         let (start_hash, start_number, start_total_difficulty) = peer_state
             .get_prove_state()
             .map(|inner| {
@@ -337,20 +338,25 @@ impl LightClientProtocol {
             .unwrap_or_else(|| {
                 let (total_difficulty, last_tip) = self.storage.get_last_state();
                 if &total_difficulty > last_total_difficulty {
-                    warn!("the last state total_difficulty in storage greater than the data in memory");
-                    warn!("storage.total_difficulty: {}, storage.last_tip: {:?}", total_difficulty, last_tip);
-                    warn!("memory.total_difficulty: {}, memory.last_tip: {:?}", last_total_difficulty, last_header.header().data());
+                    warn!(
+                        "total difficulty ({:#x}) in storage is greater than \
+                        the total difficulty ({:#x}) which requires proving",
+                        total_difficulty, last_total_difficulty
+                    );
                 }
-                (
-                    last_tip.calc_header_hash(),
-                    last_tip.raw().number().unpack(),
-                    total_difficulty,
-                )
+                let start_number: BlockNumber = last_tip.raw().number().unpack();
+                if start_number >= last_number {
+                    warn!(
+                        "block number ({}) in storage is greater than \
+                        the block number ({}) which requires proving",
+                        start_number, last_number
+                    );
+                }
+                (last_tip.calc_header_hash(), start_number, total_difficulty)
             });
-        if &start_total_difficulty > last_total_difficulty {
+        if &start_total_difficulty > last_total_difficulty || start_number >= last_number {
             return None;
         }
-        let last_number = last_header.header().number();
         let (difficulty_boundary, difficulties) = sampling::sample_blocks(
             start_number,
             &start_total_difficulty,

--- a/src/protocols/light_client/sampling.rs
+++ b/src/protocols/light_client/sampling.rs
@@ -5,8 +5,6 @@ use log::{trace, warn};
 use numext_fixed_uint::{prelude::UintConvert as _, U512};
 use rand::{thread_rng, Rng as _};
 
-use crate::protocols::LAST_N_BLOCKS;
-
 const C_FRACTION: f64 = 0.5;
 const LAMBDA: u32 = 50;
 
@@ -92,10 +90,11 @@ pub(crate) fn sample_blocks(
     start_difficulty: &U256,
     last_number: BlockNumber,
     last_difficulty: &U256,
+    last_n_blocks: BlockNumber,
 ) -> (U256, Vec<U256>) {
     let blocks_count = last_number - start_number;
-    let k = estimate_k(LAST_N_BLOCKS, blocks_count, C_FRACTION);
-    let samples_count = estimate_samples_count(blocks_count, LAST_N_BLOCKS, k, LAMBDA);
+    let k = estimate_k(last_n_blocks, blocks_count, C_FRACTION);
+    let samples_count = estimate_samples_count(blocks_count, last_n_blocks, k, LAMBDA);
 
     let delta = C_FRACTION.powf(k);
     let difficulty_range = last_difficulty - start_difficulty;
@@ -103,8 +102,9 @@ pub(crate) fn sample_blocks(
     let difficulty_boundary = start_difficulty + &difficulty_boundary_added;
 
     trace!(
-        "sampling: samples={}, delta={}, k={} in [{},{}), [{}, {}, {})",
+        "sampling: samples={}, n={}, delta={}, k={} in [{},{}), [{}, {}, {})",
         samples_count,
+        last_n_blocks,
         delta,
         k,
         start_number,

--- a/src/protocols/light_client/tests/sampling.rs
+++ b/src/protocols/light_client/tests/sampling.rs
@@ -153,6 +153,7 @@ fn test_fly_client_pdf_samples_should_be_smaller_than_the_boundary() {
 
 #[test]
 fn test_sample_blocks() {
+    let last_n_blocks = 100;
     let testcases = [
         (
             (1000, u256!("0x10000"), 1010, u256!("0x10100")),
@@ -182,6 +183,7 @@ fn test_sample_blocks() {
                 &start_difficulty,
                 last_number,
                 &last_difficulty,
+                last_n_blocks,
             );
             assert_eq!(
                 difficulty_boundary,

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -11,7 +11,7 @@ mod synchronizer;
 #[cfg(test)]
 pub(crate) use filter::GET_BLOCK_FILTERS_TOKEN;
 #[cfg(test)]
-pub(crate) use light_client::{LastState, ProveRequest, ProveState};
+pub(crate) use light_client::{LastState, PeerState, ProveRequest, ProveState};
 
 pub(crate) use filter::FilterProtocol;
 pub(crate) use light_client::{LightClientProtocol, Peers};

--- a/src/tests/protocols/light_client/mod.rs
+++ b/src/tests/protocols/light_client/mod.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use ckb_types::{
+    core::{BlockNumber, EpochNumberWithFraction, HeaderBuilder},
+    prelude::*,
+    utilities::merkle_mountain_range::VerifiableHeader,
+    U256,
+};
+
+use crate::protocols::{LightClientProtocol, PeerState, Peers, LAST_N_BLOCKS};
+
+use super::super::verify::setup;
+
+#[test]
+fn build_prove_request_content() {
+    let (storage, consensus) = setup("test-light-client");
+
+    let peers = Arc::new(Peers::default());
+    let protocol = LightClientProtocol::new(storage.clone(), peers, consensus);
+
+    let peer_state = PeerState::default();
+    let last_number = 50;
+    let last_total_difficulty = 500u64;
+    let epoch_length = LAST_N_BLOCKS + last_number + 100;
+
+    // Setup the storage.
+    {
+        let epoch = EpochNumberWithFraction::new(0, last_number, epoch_length);
+        let header = HeaderBuilder::default()
+            .number(last_number.pack())
+            .epoch(epoch.pack())
+            .build();
+        let last_total_difficulty = U256::from(500u64);
+        storage.update_last_state(&last_total_difficulty, &header.data());
+    }
+
+    // Test different total difficulties.
+    {
+        let verifiable_header = {
+            let new_last_number = last_number + 1;
+            let epoch = EpochNumberWithFraction::new(0, new_last_number, epoch_length);
+            let header = HeaderBuilder::default()
+                .number(new_last_number.pack())
+                .epoch(epoch.pack())
+                .build();
+            VerifiableHeader::new(header, Default::default(), None)
+        };
+
+        for diff in 1u64..10 {
+            let new_last_total_difficulty = U256::from(last_total_difficulty - diff);
+            let prove_request = protocol.build_prove_request_content(
+                &peer_state,
+                &verifiable_header,
+                &new_last_total_difficulty,
+            );
+            assert!(prove_request.is_none());
+        }
+        for diff in 0u64..10 {
+            let new_last_total_difficulty = U256::from(last_total_difficulty + diff);
+            let prove_request = protocol.build_prove_request_content(
+                &peer_state,
+                &verifiable_header,
+                &new_last_total_difficulty,
+            );
+            assert!(prove_request.is_some());
+            let start_number: BlockNumber = prove_request.expect("checked").start_number().unpack();
+            assert_eq!(start_number, last_number);
+        }
+    }
+
+    // Test different block numbers.
+    {
+        let new_last_total_difficulty = U256::from(last_total_difficulty * 2);
+
+        for new_last_number in 1..=last_number {
+            let verifiable_header = {
+                let epoch = EpochNumberWithFraction::new(0, new_last_number, epoch_length);
+                let header = HeaderBuilder::default()
+                    .number(new_last_number.pack())
+                    .epoch(epoch.pack())
+                    .build();
+                VerifiableHeader::new(header, Default::default(), None)
+            };
+            let prove_request = protocol.build_prove_request_content(
+                &peer_state,
+                &verifiable_header,
+                &new_last_total_difficulty,
+            );
+            assert!(prove_request.is_none());
+        }
+
+        for new_last_number in (last_number + 1)..=(last_number + 10) {
+            let verifiable_header = {
+                let epoch = EpochNumberWithFraction::new(0, new_last_number, epoch_length);
+                let header = HeaderBuilder::default()
+                    .number(new_last_number.pack())
+                    .epoch(epoch.pack())
+                    .build();
+                VerifiableHeader::new(header, Default::default(), None)
+            };
+            let prove_request = protocol.build_prove_request_content(
+                &peer_state,
+                &verifiable_header,
+                &new_last_total_difficulty,
+            );
+            assert!(prove_request.is_some());
+            let start_number: BlockNumber = prove_request.expect("checked").start_number().unpack();
+            assert_eq!(start_number, last_number);
+        }
+    }
+}

--- a/src/tests/protocols/light_client/mod.rs
+++ b/src/tests/protocols/light_client/mod.rs
@@ -89,7 +89,7 @@ fn build_prove_request_content() {
             assert!(prove_request.is_none());
         }
 
-        for new_last_number in (last_number + 1)..=(last_number + 10) {
+        for new_last_number in (last_number + 1)..=(last_number + LAST_N_BLOCKS + 10) {
             let verifiable_header = {
                 let epoch = EpochNumberWithFraction::new(0, new_last_number, epoch_length);
                 let header = HeaderBuilder::default()
@@ -104,8 +104,16 @@ fn build_prove_request_content() {
                 &new_last_total_difficulty,
             );
             assert!(prove_request.is_some());
-            let start_number: BlockNumber = prove_request.expect("checked").start_number().unpack();
+            let prove_request = prove_request.expect("checked");
+            let start_number: BlockNumber = prove_request.start_number().unpack();
             assert_eq!(start_number, last_number);
+            let difficulty_boundary: U256 = prove_request.difficulty_boundary().unpack();
+            let difficulties = prove_request.difficulties();
+            let expected_difficulty_boundary = U256::from(last_total_difficulty);
+            if new_last_number - last_number <= LAST_N_BLOCKS {
+                assert!(difficulties.is_empty());
+                assert_eq!(difficulty_boundary, expected_difficulty_boundary);
+            }
         }
     }
 }

--- a/src/tests/protocols/mod.rs
+++ b/src/tests/protocols/mod.rs
@@ -1,2 +1,3 @@
 mod block_filter;
+mod light_client;
 mod mock_context;


### PR DESCRIPTION
Skip asking proof from a peer if its proved last block number is not greater its current last block number.
Skip sampling blocks if there no enough blocks, just take all blocks.