### PR TITLE
test: add more unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,12 @@ jobs:
         scoop install llvm yasm
     - name: Build
       run: cargo build
-    - name: UnitTest
+    - if: matrix.os != 'macos-latest'
+      name: UnitTest
       run: cargo test
+    - if: matrix.os == 'macos-latest'
+      name: UnitTest
+      run: cargo test --features portable
   code_coverage:
     name: Code Coverage
     needs: [ test ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,6 @@ jobs:
         os: [ ubuntu-latest ]
     env:
       OS: ${{ matrix.os }}
-      RUST_TOOLCHAIN: nightly-2022-07-30
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,8 +23,14 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
+
+[[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "ahash"
@@ -43,7 +58,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -51,6 +66,12 @@ name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
+name = "arc-swap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "async-trait"
@@ -83,7 +104,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -100,6 +121,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bindgen"
@@ -150,11 +186,32 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -188,10 +245,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -263,7 +336,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -306,9 +379,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-block-filter"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-channel",
+ "ckb-logger",
+ "ckb-notify",
+ "ckb-store",
+ "ckb-types",
+ "golomb-coded-set",
+]
+
+[[package]]
 name = "ckb-build-info"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+
+[[package]]
+name = "ckb-chain"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-dao",
+ "ckb-error",
+ "ckb-logger",
+ "ckb-merkle-mountain-range",
+ "ckb-metrics",
+ "ckb-proposal-table",
+ "ckb-rust-unstable-port",
+ "ckb-shared",
+ "ckb-stop-handler",
+ "ckb-store",
+ "ckb-types",
+ "ckb-verification",
+ "ckb-verification-contextual",
+ "ckb-verification-traits",
+ "faketime",
+]
 
 [[package]]
 name = "ckb-chain-spec"
@@ -380,6 +491,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-db"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-db-schema",
+ "ckb-error",
+ "ckb-logger",
+ "ckb-rocksdb",
+ "libc",
+]
+
+[[package]]
+name = "ckb-db-migration"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-db",
+ "ckb-db-schema",
+ "ckb-error",
+ "ckb-logger",
+ "console",
+ "indicatif",
+]
+
+[[package]]
+name = "ckb-db-schema"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+
+[[package]]
 name = "ckb-error"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -421,6 +563,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-freezer"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-error",
+ "ckb-logger",
+ "ckb-metrics",
+ "ckb-types",
+ "ckb-util",
+ "fail",
+ "fs2",
+ "lru",
+ "snap",
+]
+
+[[package]]
 name = "ckb-hash"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -438,6 +596,47 @@ dependencies = [
  "faster-hex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ckb-launcher"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-async-runtime",
+ "ckb-block-filter",
+ "ckb-build-info",
+ "ckb-chain",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-db",
+ "ckb-db-migration",
+ "ckb-db-schema",
+ "ckb-error",
+ "ckb-freezer",
+ "ckb-jsonrpc-types",
+ "ckb-light-client-protocol-server",
+ "ckb-logger",
+ "ckb-migration-template",
+ "ckb-network",
+ "ckb-network-alert",
+ "ckb-notify",
+ "ckb-proposal-table",
+ "ckb-resource",
+ "ckb-rpc",
+ "ckb-shared",
+ "ckb-snapshot",
+ "ckb-stop-handler",
+ "ckb-store",
+ "ckb-sync",
+ "ckb-tx-pool",
+ "ckb-types",
+ "ckb-verification",
+ "ckb-verification-traits",
+ "num_cpus",
+ "once_cell",
+ "tempfile",
 ]
 
 [[package]]
@@ -461,22 +660,27 @@ dependencies = [
  "anyhow",
  "ckb-app-config",
  "ckb-async-runtime",
+ "ckb-chain",
  "ckb-chain-spec",
  "ckb-constant",
  "ckb-error",
  "ckb-jsonrpc-types",
+ "ckb-launcher",
  "ckb-merkle-mountain-range",
  "ckb-network",
  "ckb-resource",
  "ckb-rocksdb",
  "ckb-script",
+ "ckb-shared",
+ "ckb-store",
  "ckb-traits",
+ "ckb-tx-pool",
  "ckb-types",
  "ckb-verification",
  "clap 2.34.0",
  "ctrlc",
  "dashmap 5.3.4",
- "env_logger",
+ "env_logger 0.9.0",
  "faketime",
  "golomb-coded-set",
  "jsonrpc-core",
@@ -498,6 +702,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-light-client-protocol-server"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-logger",
+ "ckb-merkle-mountain-range",
+ "ckb-network",
+ "ckb-shared",
+ "ckb-store",
+ "ckb-sync",
+ "ckb-types",
+]
+
+[[package]]
 name = "ckb-logger"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -511,6 +729,37 @@ version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ckb-logger-service"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ansi_term",
+ "backtrace",
+ "ckb-channel",
+ "ckb-logger-config",
+ "ckb-util",
+ "env_logger 0.6.2",
+ "log",
+ "once_cell",
+ "regex",
+ "time",
+]
+
+[[package]]
+name = "ckb-memory-tracker"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-db",
+ "ckb-logger",
+ "ckb-metrics",
+ "libc",
+ "once_cell",
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -539,6 +788,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-migration-template"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ckb-multisig"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-crypto",
+ "ckb-error",
+ "ckb-logger",
+]
+
+[[package]]
 name = "ckb-network"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -563,6 +831,37 @@ dependencies = [
  "tentacle",
  "tokio",
  "tokio-util 0.7.3",
+]
+
+[[package]]
+name = "ckb-network-alert"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-error",
+ "ckb-jsonrpc-types",
+ "ckb-logger",
+ "ckb-multisig",
+ "ckb-network",
+ "ckb-notify",
+ "ckb-types",
+ "ckb-util",
+ "faketime",
+ "lru",
+ "semver",
+]
+
+[[package]]
+name = "ckb-notify"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-channel",
+ "ckb-logger",
+ "ckb-stop-handler",
+ "ckb-types",
 ]
 
 [[package]]
@@ -606,6 +905,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-proposal-table"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-chain-spec",
+ "ckb-logger",
+ "ckb-types",
+]
+
+[[package]]
 name = "ckb-rational"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -629,6 +938,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-reward-calculator"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-chain-spec",
+ "ckb-dao",
+ "ckb-dao-utils",
+ "ckb-logger",
+ "ckb-store",
+ "ckb-types",
+]
+
+[[package]]
 name = "ckb-rocksdb"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +959,56 @@ dependencies = [
  "ckb-librocksdb-sys",
  "libc",
  "tempfile",
+]
+
+[[package]]
+name = "ckb-rpc"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-chain",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-constant",
+ "ckb-dao",
+ "ckb-error",
+ "ckb-jsonrpc-types",
+ "ckb-logger",
+ "ckb-logger-service",
+ "ckb-memory-tracker",
+ "ckb-network",
+ "ckb-network-alert",
+ "ckb-notify",
+ "ckb-pow",
+ "ckb-reward-calculator",
+ "ckb-shared",
+ "ckb-store",
+ "ckb-sync",
+ "ckb-traits",
+ "ckb-tx-pool",
+ "ckb-types",
+ "ckb-util",
+ "ckb-verification",
+ "ckb-verification-traits",
+ "faketime",
+ "jsonrpc-core",
+ "jsonrpc-derive",
+ "jsonrpc-http-server",
+ "jsonrpc-pubsub",
+ "jsonrpc-server-utils",
+ "jsonrpc-tcp-server",
+ "jsonrpc-ws-server",
+ "num_cpus",
+ "serde_json",
+]
+
+[[package]]
+name = "ckb-rust-unstable-port"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "is_sorted",
 ]
 
 [[package]]
@@ -657,6 +1029,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-shared"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "arc-swap",
+ "ckb-async-runtime",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-constant",
+ "ckb-db",
+ "ckb-db-schema",
+ "ckb-error",
+ "ckb-logger",
+ "ckb-notify",
+ "ckb-proposal-table",
+ "ckb-snapshot",
+ "ckb-stop-handler",
+ "ckb-store",
+ "ckb-tx-pool",
+ "ckb-types",
+ "ckb-verification",
+ "faketime",
+]
+
+[[package]]
+name = "ckb-snapshot"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "arc-swap",
+ "ckb-chain-spec",
+ "ckb-db",
+ "ckb-db-schema",
+ "ckb-freezer",
+ "ckb-merkle-mountain-range",
+ "ckb-proposal-table",
+ "ckb-store",
+ "ckb-traits",
+ "ckb-types",
+]
+
+[[package]]
 name = "ckb-spawn"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -669,6 +1083,61 @@ dependencies = [
  "ckb-channel",
  "ckb-logger",
  "parking_lot 0.12.1",
+ "tokio",
+]
+
+[[package]]
+name = "ckb-store"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-chain-spec",
+ "ckb-db",
+ "ckb-db-schema",
+ "ckb-error",
+ "ckb-freezer",
+ "ckb-merkle-mountain-range",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-util",
+ "lru",
+]
+
+[[package]]
+name = "ckb-sync"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "bitflags",
+ "ckb-app-config",
+ "ckb-async-runtime",
+ "ckb-chain",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-constant",
+ "ckb-error",
+ "ckb-hash",
+ "ckb-logger",
+ "ckb-metrics",
+ "ckb-network",
+ "ckb-shared",
+ "ckb-stop-handler",
+ "ckb-store",
+ "ckb-traits",
+ "ckb-tx-pool",
+ "ckb-types",
+ "ckb-util",
+ "ckb-verification",
+ "ckb-verification-traits",
+ "dashmap 4.0.2",
+ "faketime",
+ "futures",
+ "governor",
+ "keyed_priority_queue",
+ "lru",
+ "sled",
+ "tempfile",
  "tokio",
 ]
 
@@ -694,12 +1163,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-tx-pool"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-app-config",
+ "ckb-async-runtime",
+ "ckb-chain-spec",
+ "ckb-channel",
+ "ckb-dao",
+ "ckb-db",
+ "ckb-error",
+ "ckb-jsonrpc-types",
+ "ckb-logger",
+ "ckb-network",
+ "ckb-reward-calculator",
+ "ckb-snapshot",
+ "ckb-stop-handler",
+ "ckb-store",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-util",
+ "ckb-verification",
+ "faketime",
+ "hyper",
+ "lru",
+ "rand 0.8.5",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "ckb-types"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
 dependencies = [
  "bit-vec",
- "bytes",
+ "bytes 1.1.0",
  "ckb-channel",
  "ckb-error",
  "ckb-fixed-hash",
@@ -745,6 +1245,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-verification-contextual"
+version = "0.105.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
+dependencies = [
+ "ckb-async-runtime",
+ "ckb-chain-spec",
+ "ckb-dao",
+ "ckb-dao-utils",
+ "ckb-error",
+ "ckb-logger",
+ "ckb-merkle-mountain-range",
+ "ckb-reward-calculator",
+ "ckb-store",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-verification",
+ "ckb-verification-traits",
+ "faketime",
+ "rayon",
+ "tokio",
+]
+
+[[package]]
 name = "ckb-verification-traits"
 version = "0.105.0-pre"
 source = "git+https://github.com/nervosnetwork/ckb?rev=0acf5b1414f5921b7374a29d082450c917a5b046#0acf5b1414f5921b7374a29d082450c917a5b046"
@@ -760,7 +1283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c5f3cff8cb9e28295f32a35b0aa9faa988bf992d06ce3d304abb3e0fbf2d8c7"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 1.1.0",
  "cc",
  "ckb-vm-definitions",
  "derive_more",
@@ -840,6 +1363,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1411,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg 1.1.0",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,7 +1451,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "typenum",
 ]
 
@@ -900,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
  "nix",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -959,11 +1521,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -972,7 +1543,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
 ]
@@ -990,17 +1561,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d978bd5d343e8ab9b5c0fc8d93ff9c602fdc96616ffff9c05ac7a155419b824"
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "env_logger"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "fail"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "faketime"
@@ -1069,10 +1682,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -1114,6 +1759,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1146,6 +1792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1813,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1196,6 +1866,12 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "glob"
@@ -1248,6 +1924,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c5d2f987ee8f6dff3fa1a352058dc59b990e447e4c7846aa7d804971314f7b"
+dependencies = [
+ "dashmap 4.0.2",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.11.2",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg 1.1.0",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1962,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1268,7 +1971,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1295,7 +1998,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -1306,7 +2009,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "http",
  "pin-project-lite",
 ]
@@ -1325,6 +2028,15 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1335,7 +2047,7 @@ version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1408,12 +2120,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1424,6 +2157,12 @@ checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "is_sorted"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
 
 [[package]]
 name = "itoa"
@@ -1493,12 +2232,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-pubsub"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
+dependencies = [
+ "futures",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "parking_lot 0.11.2",
+ "rand 0.7.3",
+ "serde",
+]
+
+[[package]]
 name = "jsonrpc-server-utils"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "futures",
  "globset",
  "jsonrpc-core",
@@ -1508,6 +2262,53 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.6.10",
  "unicase",
+]
+
+[[package]]
+name = "jsonrpc-tcp-server"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a0a0d35558123e93743d467285196905da1368500378cb5352b71856377874"
+dependencies = [
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "parking_lot 0.11.2",
+ "tower-service",
+]
+
+[[package]]
+name = "jsonrpc-ws-server"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
+dependencies = [
+ "futures",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "parity-ws",
+ "parking_lot 0.11.2",
+ "slab",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "keyed_priority_queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a59df08c683d655315a5a674004a3da802743579069278fa07c37cf8a3e8d4"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]
@@ -1535,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1579,7 +2380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1593,6 +2394,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "merkle-cbt"
@@ -1620,6 +2430,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
@@ -1631,12 +2460,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
 name = "molecule"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "cfg-if 1.0.0",
  "faster-hex",
 ]
@@ -1649,7 +2502,7 @@ checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1661,6 +2514,15 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "hashbrown 0.8.2",
 ]
 
 [[package]]
@@ -1680,6 +2542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonzero_ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +2556,21 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numext-constructor"
@@ -1736,10 +2619,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1817,6 +2715,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
+name = "parity-ws"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5983d3929ad50f12c3eb9a6743f19d691866ecd44da74c0a3308c3f8a56df0c6"
+dependencies = [
+ "byteorder",
+ "bytes 0.4.12",
+ "httparse",
+ "log",
+ "mio 0.6.23",
+ "mio-extras",
+ "rand 0.7.3",
+ "sha-1",
+ "slab",
+ "url",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,7 +2764,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1863,6 +2779,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "path-clean"
@@ -1951,7 +2873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -1980,6 +2902,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98dc777a7a39b76b1a26ae9d3f691f4c1bc0455090aa0b64dfa8cb7fc34c135"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,7 +2942,7 @@ dependencies = [
  "rand_os",
  "rand_pcg 0.1.2",
  "rand_xorshift",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2130,7 +3068,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2144,7 +3082,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2173,6 +3111,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg 1.1.0",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2216,7 +3178,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2231,7 +3193,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2243,6 +3205,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -2365,6 +3333,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +3383,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,7 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2482,7 +3478,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2492,7 +3488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dce982ed9b672847c08a1feb56e8976586189d1ee617856a7e97fe3d748a26"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.1.0",
  "futures",
  "igd",
  "js-sys",
@@ -2512,7 +3508,7 @@ dependencies = [
  "tokio-yamux",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2522,7 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faafcea0d508fc5296ca846ca1f2fcb60d740f53b02e771b407c06ae13e23c90"
 dependencies = [
  "bs58",
- "bytes",
+ "bytes 1.1.0",
  "serde",
  "sha2",
  "unsigned-varint",
@@ -2535,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25404f0ad099d7ac35c4873e854a1f9772014b1c42379780f7b9f55fa464913"
 dependencies = [
  "bs58",
- "bytes",
+ "bytes 1.1.0",
  "chacha20poly1305",
  "futures",
  "hmac",
@@ -2562,6 +3558,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2600,6 +3606,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb833c46ecbf8b6daeccb347cefcabf9c1beb5c9b0f853e1cec45632d9963e69"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,10 +3660,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg 1.1.0",
- "bytes",
+ "bytes 1.1.0",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.3",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2632,7 +3671,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2663,7 +3702,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log",
@@ -2677,7 +3716,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2691,7 +3730,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129b802888b976c5b14aefc5f11d563ed25eaceb74a9e6e03d1d1de50d994cc7"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
  "futures",
  "log",
  "nohash-hasher",
@@ -2803,7 +3842,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -2857,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -2973,6 +4012,12 @@ checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2980,6 +4025,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2993,7 +4044,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3044,6 +4095,16 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,14 +442,16 @@ dependencies = [
 
 [[package]]
 name = "ckb-librocksdb-sys"
-version = "6.20.4"
+version = "7.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302b396464eba5ef2e728f1e242096d411d9aa4be81da59f6a761046a6695e6b"
+checksum = "d106bb32241da368e67ce9a36545e1cc3c31b7faa9321817199b69bf1e085b4a"
 dependencies = [
  "bindgen",
  "cc",
- "glob 0.2.11",
+ "glob",
  "libc",
+ "pkg-config",
+ "rust-ini",
 ]
 
 [[package]]
@@ -628,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rocksdb"
-version = "0.16.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635a60810185d2903461565ca8e177ee480c41dd63a294b662fd7ea242ce3033"
+checksum = "87b89828fd7e60e4d857f6f1a2f40343114eece1ca20859d4ca8371d4e00ce28"
 dependencies = [
  "ckb-librocksdb-sys",
  "libc",
@@ -783,7 +785,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
- "glob 0.3.0",
+ "glob",
  "libc",
  "libloading",
 ]
@@ -974,6 +976,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "eaglesong"
@@ -1188,12 +1196,6 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 
 [[package]]
 name = "glob"
@@ -1538,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1796,6 +1798,16 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "thiserror",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -2220,6 +2232,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ jsonrpc-http-server = "18.0"
 jsonrpc-server-utils = "18.0"
 
 [dev-dependencies]
+ckb-launcher    = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-shared      = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-chain       = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-tx-pool     = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
+ckb-store       = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
 tempfile = "3.0"
 rand = "0.6"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1
 ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "0acf5b1414f5921b7374a29d082450c917a5b046" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
-rocksdb = { package = "ckb-rocksdb", version ="=0.16.1", features = ["snappy"] }
+rocksdb = { package = "ckb-rocksdb", version ="=0.18.3", features = ["snappy"] }
 numext-fixed-uint = { version = "0.1", features = ["support_rand", "support_heapsize", "support_serde"] }
 anyhow = "1.0.56"
 thiserror = "1.0.30"
@@ -36,7 +36,7 @@ ctrlc = { version = "3.2.1", features = ["termination"] }
 path-clean = "0.1.0"
 rand = "0.8.5"
 dashmap = "5.3"
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.6"
 faketime = "0.2.1"
 jsonrpc-core = "18.0"
 jsonrpc-derive = "18.0"
@@ -48,6 +48,10 @@ tempfile = "3.0"
 rand = "0.6"
 serde_json = "1.0"
 tokio = { version = "1.20" }
+
+[features]
+default = []
+portable = ["rocksdb/portable"]
 
 [profile.release]
 overflow-checks = true

--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -18,7 +18,6 @@ use log::{error, trace, warn};
 use super::super::{
     peers::ProveRequest, prelude::*, LastState, LightClientProtocol, ProveState, Status, StatusCode,
 };
-use crate::protocols::LAST_N_BLOCKS;
 
 pub(crate) struct SendLastStateProofProcess<'a> {
     message: packed::SendLastStateProofReader<'a>,
@@ -75,7 +74,7 @@ impl<'a> SendLastStateProofProcess<'a> {
         // Check if the response is match the request.
         let (reorg_count, sampled_count, last_n_count) =
             return_if_failed!(check_if_response_is_matched(
-                LAST_N_BLOCKS as usize,
+                self.protocol.last_n_blocks() as usize,
                 original_request.get_content(),
                 &headers,
             ));
@@ -483,12 +482,12 @@ pub(crate) fn check_if_response_is_matched(
     prev_request: &packed::GetLastStateProof,
     headers: &[VerifiableHeader],
 ) -> Result<(usize, usize, usize), Status> {
-    // Headers should be ordered.
+    // Headers should be sorted.
     if headers
         .windows(2)
         .any(|hs| hs[0].header().number() >= hs[1].header().number())
     {
-        let errmsg = "headers should be ordered (monotonic increasing)";
+        let errmsg = "headers should be sorted (monotonic increasing)";
         return Err(StatusCode::MalformedProtocolMessage.with_context(errmsg));
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod prelude;
 
+pub(crate) mod utils;
+
 // The unit tests for modules which are in the root path of this crate.
 mod protocols;
 mod service;

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -1,3 +1,24 @@
+use std::sync::Arc;
+
+use ckb_chain::chain::ChainController;
+use ckb_chain_spec::consensus::Consensus;
+use ckb_merkle_mountain_range::leaf_index_to_pos;
+use ckb_shared::{Shared, Snapshot};
+use ckb_store::ChainStore;
+use ckb_tx_pool::TxPoolController;
+use ckb_types::{
+    core::{BlockExt, BlockNumber, BlockView, HeaderView},
+    packed,
+    prelude::*,
+    utilities::{compact_to_difficulty, merkle_mountain_range::VerifiableHeader},
+    U256,
+};
+
+use crate::{
+    protocols::{FilterProtocol, LastState, LightClientProtocol, Peers, ProveRequest},
+    storage::Storage,
+};
+
 macro_rules! epoch {
     ($number:expr, $index:expr, $length:expr) => {
         ckb_types::core::EpochNumberWithFraction::new($number, $index, $length)
@@ -6,4 +27,194 @@ macro_rules! epoch {
         let (number, index, length) = $tuple;
         ckb_types::core::EpochNumberWithFraction::new(number, index, length)
     }};
+}
+
+pub(crate) trait SnapshotExt {
+    fn get_header_by_number(&self, num: BlockNumber) -> Option<HeaderView>;
+
+    fn get_block_by_number(&self, num: BlockNumber) -> Option<BlockView>;
+
+    fn get_block_ext_by_number(&self, num: BlockNumber) -> Option<BlockExt>;
+
+    fn get_verifiable_header_by_number(&self, num: BlockNumber)
+        -> Option<packed::VerifiableHeader>;
+
+    fn get_block_difficulty_by_number(&self, num: BlockNumber) -> Option<U256> {
+        self.get_header_by_number(num)
+            .map(|header| compact_to_difficulty(header.compact_target()))
+    }
+
+    fn get_total_difficulty_by_number(&self, num: BlockNumber) -> Option<U256> {
+        self.get_block_ext_by_number(num)
+            .map(|block_ext| block_ext.total_difficulty)
+    }
+
+    fn build_last_state_by_number(&self, num: BlockNumber) -> Option<packed::LightClientMessage> {
+        self.get_verifiable_header_by_number(num).map(|header| {
+            let content = packed::SendLastState::new_builder()
+                .last_header(header)
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        })
+    }
+}
+
+pub(crate) trait ChainExt {
+    fn client_storage(&self) -> &Storage;
+
+    fn consensus(&self) -> &Consensus;
+
+    fn create_light_client_protocol(&self, peers: Arc<Peers>) -> LightClientProtocol {
+        let storage = self.client_storage().to_owned();
+        let consensus = self.consensus().to_owned();
+        LightClientProtocol::new(storage, peers, consensus)
+    }
+
+    fn create_filter_protocol(&self, peers: Arc<Peers>) -> FilterProtocol {
+        let storage = self.client_storage().to_owned();
+        FilterProtocol::new(storage, peers)
+    }
+}
+
+pub(crate) trait RunningChainExt: ChainExt {
+    fn controller(&self) -> &ChainController;
+
+    fn shared(&self) -> &Shared;
+
+    fn tx_pool(&self) -> &TxPoolController {
+        &self.shared().tx_pool_controller()
+    }
+
+    fn mine_to(&self, block_number: BlockNumber) {
+        let chain_tip_number = self.shared().snapshot().tip_number();
+        if chain_tip_number < block_number {
+            self.mine_blocks((block_number - chain_tip_number) as usize);
+        }
+    }
+
+    fn mine_blocks(&self, blocks_count: usize) {
+        for _ in 0..blocks_count {
+            let block_template = self
+                .shared()
+                .get_block_template(None, None, None)
+                .unwrap()
+                .unwrap();
+
+            let block: packed::Block = block_template.into();
+            let block = block.as_advanced_builder().build();
+            let block_number = block.number();
+            let is_ok = self
+                .controller()
+                .process_block(Arc::new(block))
+                .expect("process block");
+            assert!(is_ok, "failed to process block {}", block_number);
+
+            while self
+                .tx_pool()
+                .get_tx_pool_info()
+                .expect("get tx pool info")
+                .tip_number
+                != block_number
+            {}
+        }
+    }
+
+    fn build_prove_request(
+        &self,
+        last_num: BlockNumber,
+        sampled_nums: &[BlockNumber],
+        boundary_num: BlockNumber,
+        last_n_blocks: BlockNumber,
+    ) -> ProveRequest {
+        let snapshot = self.shared().snapshot();
+        let last_header: VerifiableHeader = snapshot
+            .get_verifiable_header_by_number(last_num)
+            .expect("block stored")
+            .into();
+        let content = {
+            let genesis_block = self.consensus().genesis_block();
+            let difficulties = {
+                let u256_one = &U256::from(1u64);
+                let total_diffs = (0..last_num)
+                    .into_iter()
+                    .map(|num| snapshot.get_total_difficulty_by_number(num).unwrap())
+                    .collect::<Vec<_>>();
+                let mut difficulties = Vec::new();
+                for n in sampled_nums {
+                    let n = *n as usize;
+                    difficulties.push(&total_diffs[n - 1] + u256_one);
+                    difficulties.push(&total_diffs[n] - u256_one);
+                    difficulties.push(total_diffs[n].to_owned());
+                }
+                difficulties.into_iter().map(|diff| diff.pack())
+            };
+            let difficulty_boundary = snapshot
+                .get_total_difficulty_by_number(boundary_num)
+                .unwrap();
+            packed::GetLastStateProof::new_builder()
+                .last_hash(last_header.header().hash())
+                .start_hash(genesis_block.hash())
+                .start_number(genesis_block.number().pack())
+                .last_n_blocks(last_n_blocks.pack())
+                .difficulty_boundary(difficulty_boundary.pack())
+                .difficulties(difficulties.pack())
+                .build()
+        };
+        let last_state = LastState::new(last_header);
+        ProveRequest::new(last_state, content)
+    }
+
+    fn build_proof_by_numbers(
+        &self,
+        last_num: BlockNumber,
+        block_nums: &[BlockNumber],
+    ) -> packed::HeaderDigestVec {
+        let positions = block_nums
+            .iter()
+            .map(|num| leaf_index_to_pos(*num))
+            .collect();
+        self.shared()
+            .snapshot()
+            .chain_root_mmr(last_num - 1)
+            .gen_proof(positions)
+            .expect("generate proof")
+            .proof_items()
+            .to_owned()
+            .pack()
+    }
+}
+
+impl SnapshotExt for Snapshot {
+    fn get_header_by_number(&self, num: BlockNumber) -> Option<HeaderView> {
+        self.get_block_hash(num)
+            .and_then(|hash| self.get_block_header(&hash))
+    }
+
+    fn get_block_by_number(&self, num: BlockNumber) -> Option<BlockView> {
+        self.get_block_hash(num)
+            .and_then(|hash| self.get_block(&hash))
+    }
+
+    fn get_block_ext_by_number(&self, num: BlockNumber) -> Option<BlockExt> {
+        self.get_block_hash(num)
+            .and_then(|hash| self.get_block_ext(&hash))
+    }
+
+    fn get_verifiable_header_by_number(
+        &self,
+        num: BlockNumber,
+    ) -> Option<packed::VerifiableHeader> {
+        self.get_block_by_number(num).map(|block| {
+            let mmr = self.chain_root_mmr(num - 1);
+            let parent_chain_root = mmr.get_root().expect("has chain root");
+            packed::VerifiableHeader::new_builder()
+                .header(block.data().header())
+                .uncles_hash(block.calc_uncles_hash())
+                .extension(Pack::pack(&block.extension()))
+                .parent_chain_root(parent_chain_root)
+                .build()
+        })
+    }
 }

--- a/src/tests/protocols/light_client/send_last_state.rs
+++ b/src/tests/protocols/light_client/send_last_state.rs
@@ -1,0 +1,342 @@
+use std::sync::Arc;
+
+use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
+use ckb_types::{
+    core::{EpochNumberWithFraction, HeaderBuilder},
+    packed::{self},
+    prelude::*,
+    utilities::merkle_mountain_range::VerifiableHeader,
+};
+
+use crate::{
+    protocols::{LastState, Peers, ProveRequest, ProveState, StatusCode},
+    tests::{
+        prelude::*,
+        utils::{MockChain, MockNetworkContext},
+    },
+};
+
+#[tokio::test]
+async fn peer_state_is_not_found() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peers = Arc::new(Peers::default());
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let data = {
+        let content = packed::SendLastState::new_builder().build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    let peer_index = PeerIndex::new(1);
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::PeerStateIsNotFound));
+}
+
+#[tokio::test]
+async fn invalid_nonce() {
+    let chain = MockChain::new_with_default_pow("test-light-client");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let data = {
+        let content = packed::SendLastState::new_builder().build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidNonce));
+}
+
+#[tokio::test]
+async fn invalid_chain_root() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let data = {
+        let header = HeaderBuilder::default()
+            .epoch(EpochNumberWithFraction::new(1, 0, 10).pack())
+            .number(11u64.pack())
+            .build();
+        let last_header = packed::VerifiableHeader::new_builder()
+            .header(header.data())
+            .build();
+        let content = packed::SendLastState::new_builder()
+            .last_header(last_header)
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidChainRoot));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn initialize_last_state() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let num = 12;
+    chain.mine_to(12);
+
+    let snapshot = chain.shared().snapshot();
+
+    let last_header = snapshot
+        .get_verifiable_header_by_number(num)
+        .expect("block stored");
+    let last_hash = last_header.header().calc_header_hash();
+    let data = {
+        let content = packed::SendLastState::new_builder()
+            .last_header(last_header)
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    let peer_state = protocol
+        .get_peer_state(&peer_index)
+        .expect("has peer state");
+    assert!(peer_state.get_last_state().is_none());
+    assert!(nc.sent_messages().borrow().is_empty());
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.not_banned(peer_index));
+
+    let peer_state = protocol
+        .get_peer_state(&peer_index)
+        .expect("has peer state");
+    assert!(peer_state.get_last_state().is_some());
+    assert_eq!(nc.sent_messages().borrow().len(), 1);
+
+    let data = &nc.sent_messages().borrow()[0].2;
+    let message = packed::LightClientMessageReader::new_unchecked(&data);
+    let content = if let packed::LightClientMessageUnionReader::GetLastStateProof(content) =
+        message.to_enum()
+    {
+        content
+    } else {
+        panic!("unexpected message");
+    };
+    assert_eq!(content.last_hash().as_slice(), last_hash.as_slice());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_to_continuous_last_state() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let mut num = 12;
+    chain.mine_to(num + 1);
+
+    let snapshot = chain.shared().snapshot();
+
+    // Setup the test fixture:
+    // - Update last state.
+    // - Commit prove state.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        assert!(peer_state.get_prove_state().is_none());
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        let prove_state = {
+            let last_n_headers = (1..num)
+                .into_iter()
+                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
+                .collect::<Vec<_>>();
+            ProveState::new_from_request(prove_request, Vec::new(), last_n_headers)
+        };
+        protocol.commit_prove_state(peer_index, prove_state);
+    }
+
+    num += 1;
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let content = packed::SendLastState::new_builder()
+                .last_header(last_header.clone())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+        let last_header: VerifiableHeader = last_header.into();
+        let last_state = LastState::new(last_header.clone());
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        assert!(prove_state.is_parent_of(&last_state));
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.sent_messages().borrow().is_empty());
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        assert!(prove_state.is_same_as(&last_header));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_to_noncontinuous_last_state() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let mut num = 12;
+    chain.mine_to(num + 2);
+
+    let snapshot = chain.shared().snapshot();
+
+    // Setup the test fixture:
+    // - Update last state.
+    // - Commit prove state.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        assert!(peer_state.get_prove_state().is_none());
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        let prove_state = {
+            let last_n_headers = (1..num)
+                .into_iter()
+                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
+                .collect::<Vec<_>>();
+            ProveState::new_from_request(prove_request, Vec::new(), last_n_headers)
+        };
+        protocol.commit_prove_state(peer_index, prove_state);
+    }
+
+    num += 2;
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let content = packed::SendLastState::new_builder()
+                .last_header(last_header.clone())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+        let last_header: VerifiableHeader = last_header.into();
+        let last_state = LastState::new(last_header.clone());
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        assert!(!prove_state.is_parent_of(&last_state));
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.sent_messages().borrow().is_empty());
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        assert!(!prove_state.is_same_as(&last_header));
+    }
+}

--- a/src/tests/protocols/light_client/send_last_state_proof.rs
+++ b/src/tests/protocols/light_client/send_last_state_proof.rs
@@ -1,0 +1,812 @@
+use std::{cmp, sync::Arc};
+
+use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
+use ckb_types::{
+    core::BlockNumber, packed, prelude::*, utilities::merkle_mountain_range::VerifiableHeader, U256,
+};
+
+use crate::{
+    protocols::{LastState, Peers, ProveRequest, StatusCode},
+    tests::{
+        prelude::*,
+        utils::{MockChain, MockNetworkContext},
+    },
+};
+
+#[tokio::test]
+async fn peer_state_is_not_found() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peers = Arc::new(Peers::default());
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let data = {
+        let content = packed::SendLastStateProof::new_builder().build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    let peer_index = PeerIndex::new(1);
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::PeerStateIsNotFound));
+}
+
+#[tokio::test]
+async fn no_matched_request() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let data = {
+        let content = packed::SendLastStateProof::new_builder().build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.not_banned(peer_index));
+
+    let peer_state = protocol
+        .get_peer_state(&peer_index)
+        .expect("has peer state");
+    assert!(peer_state.get_prove_state().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_last_state() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let mut num = 12;
+    chain.mine_to(12 + 2);
+
+    let snapshot = chain.shared().snapshot();
+
+    // Setup the test fixture.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    num += 2;
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let last_hash = last_header.header().calc_header_hash();
+        let data = {
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header)
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        assert!(nc.sent_messages().borrow().is_empty());
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+
+        assert_eq!(nc.sent_messages().borrow().len(), 1);
+
+        let data = &nc.sent_messages().borrow()[0].2;
+        let message = packed::LightClientMessageReader::new_unchecked(&data);
+        let content = if let packed::LightClientMessageUnionReader::GetLastStateProof(content) =
+            message.to_enum()
+        {
+            content
+        } else {
+            panic!("unexpected message");
+        };
+        assert_eq!(content.last_hash().as_slice(), last_hash.as_slice());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_proof() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let mut num = 12;
+    chain.mine_to(12 + 2);
+
+    let snapshot = chain.shared().snapshot();
+
+    // Setup the test fixture.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    num += 2;
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let item = packed::HeaderDigest::default();
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header)
+                .proof(vec![item].pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        assert!(nc.sent_messages().borrow().is_empty());
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+        assert!(nc.sent_messages().borrow().is_empty());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn headers_should_be_sorted() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    // Setup the test fixture.
+    {
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = {
+                let genesis_block = chain.consensus().genesis_block();
+                packed::GetLastStateProof::new_builder()
+                    .last_hash(last_header.header().hash())
+                    .start_hash(genesis_block.hash())
+                    .start_number(genesis_block.number().pack())
+                    .last_n_blocks(protocol.last_n_blocks().pack())
+                    .difficulty_boundary(U256::zero().pack())
+                    .build()
+            };
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let item = packed::HeaderDigest::default();
+            let headers = (1..num)
+                .into_iter()
+                .map(|mut n| {
+                    if n == 1 {
+                        n = num / 2;
+                    } else if n == num / 2 {
+                        n = 1;
+                    }
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header)
+                .proof(vec![item].pack())
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.banned_since(peer_index, StatusCode::MalformedProtocolMessage));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_with_boundary_not_in_last_n() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() - 2;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        let last_header: VerifiableHeader = last_header.into();
+        assert!(prove_state.is_same_as(&last_header));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_with_boundary_in_last_n() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() + 1;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        let last_header: VerifiableHeader = last_header.into();
+        assert!(prove_state.is_same_as(&last_header));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() + 1;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .skip(1)
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.banned_since(peer_index, StatusCode::InvalidProof));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn samples_are_incorrect() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let bad_sampled_numbers = vec![3, 5, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() - 2;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = bad_sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.banned_since(peer_index, StatusCode::InvalidSamples));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn samples_are_redundant() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let bad_sampled_numbers = vec![3, 5, 7, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() - 2;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = bad_sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.banned_since(peer_index, StatusCode::InvalidSamples));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn last_n_headers_should_be_continuous() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let sampled_numbers = vec![3, 7, 11, 18];
+    let boundary_number = num - protocol.last_n_blocks() - 2;
+
+    // Setup the test fixture.
+    {
+        let mut prove_request = chain.build_prove_request(
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain(
+                    (first_last_n_number..num)
+                        .into_iter()
+                        .filter(|n| *n != first_last_n_number + 1),
+                )
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.banned_since(peer_index, StatusCode::InvalidParentHash));
+    }
+}

--- a/src/tests/protocols/mod.rs
+++ b/src/tests/protocols/mod.rs
@@ -1,3 +1,2 @@
 mod block_filter;
 mod light_client;
-mod mock_context;

--- a/src/tests/specs/dummy_pow.toml
+++ b/src/tests/specs/dummy_pow.toml
@@ -1,0 +1,106 @@
+name = "ckb_dev"
+
+[genesis]
+version = 0
+parent_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+timestamp = 0
+compact_target = 0x2080_0000
+uncles_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+nonce = "0x0"
+
+[genesis.genesis_cell]
+message = "ckb-light-client-test"
+
+[genesis.genesis_cell.lock]
+code_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+args = "0x"
+hash_type = "data"
+
+# An array list paths to system cell files, which is absolute or relative to
+# the directory containing this config file.
+[[genesis.system_cells]]
+file = { bundled = "specs/cells/secp256k1_blake160_sighash_all" }
+create_type_id = true
+capacity = 100_000_0000_0000
+[[genesis.system_cells]]
+file = { bundled = "specs/cells/dao" }
+create_type_id = true
+capacity = 16_000_0000_0000
+[[genesis.system_cells]]
+file = { bundled = "specs/cells/secp256k1_data" }
+create_type_id = false
+capacity = 1_048_617_0000_0000
+[[genesis.system_cells]]
+file = { bundled = "specs/cells/secp256k1_blake160_multisig_all" }
+create_type_id = true
+capacity = 100_000_0000_0000
+
+[genesis.system_cells_lock]
+code_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+args = "0x"
+hash_type = "data"
+
+# Dep group cells
+[[genesis.dep_groups]]
+name = "secp256k1_blake160_sighash_all"
+files = [
+  { bundled = "specs/cells/secp256k1_data" },
+  { bundled = "specs/cells/secp256k1_blake160_sighash_all" },
+]
+[[genesis.dep_groups]]
+name = "secp256k1_blake160_multisig_all"
+files = [
+  { bundled = "specs/cells/secp256k1_data" },
+  { bundled = "specs/cells/secp256k1_blake160_multisig_all" },
+]
+
+# For first 11 block
+[genesis.bootstrap_lock]
+code_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+args = "0x"
+hash_type = "type"
+
+# Burn
+[[genesis.issued_cells]]
+capacity = 8_400_000_000_00000000
+lock.code_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+lock.args = "0x62e907b15cbf27d5425399ebf6f0fb50ebb88f18"
+lock.hash_type = "data"
+
+# issue for random generated private key: d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc
+[[genesis.issued_cells]]
+capacity = 20_000_000_000_00000000
+lock.code_hash = "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"
+lock.args = "0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7"
+lock.hash_type = "type"
+
+# issue for random generated private key: 63d86723e08f0f813a36ce6aa123bb2289d90680ae1e99d4de8cdb334553f24d
+[[genesis.issued_cells]]
+capacity = 5_198_735_037_00000000
+lock.code_hash = "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"
+lock.args = "0x470dcdc5e44064909650113a274b3b36aecb6dc7"
+lock.hash_type = "type"
+
+[params]
+initial_primary_epoch_reward = 1_917_808_21917808
+secondary_epoch_reward = 613_698_63013698
+max_block_cycles = 10_000_000_000
+cellbase_maturity = 0
+primary_epoch_reward_halving_interval = 8760
+epoch_duration_target = 14400
+genesis_epoch_length = 10
+# For development and testing purposes only.
+# Keep difficulty be permanent if the pow is Dummy. (default: false)
+permanent_difficulty_in_dummy = true
+
+[params.hardfork]
+rfc_0028 = 0
+rfc_0029 = 0
+rfc_0030 = 0
+rfc_0031 = 0
+rfc_0032 = 0
+rfc_0036 = 0
+rfc_0038 = 0
+
+[pow]
+func = "Dummy"

--- a/src/tests/utils/chain.rs
+++ b/src/tests/utils/chain.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use ckb_app_config::{BlockAssemblerConfig, NetworkConfig};
+use ckb_chain::chain::{ChainController, ChainService};
+use ckb_chain_spec::{consensus::Consensus, ChainSpec};
+use ckb_jsonrpc_types::ScriptHashType;
+use ckb_launcher::SharedBuilder;
+use ckb_network::{DefaultExitHandler, NetworkController, NetworkService, NetworkState};
+use ckb_resource::Resource;
+use ckb_shared::Shared;
+use ckb_types::h256;
+
+use crate::{storage::Storage, tests::prelude::*};
+
+/// Mock a chain without starting services.
+pub(crate) struct MockChain {
+    storage: Storage,
+    consensus: Consensus,
+}
+
+/// Mock a chain and start its services.
+pub(crate) struct MockRunningChain {
+    storage: Storage,
+    chain_controller: ChainController,
+    shared: Shared,
+}
+
+impl ChainExt for MockChain {
+    fn client_storage(&self) -> &Storage {
+        &self.storage
+    }
+
+    fn consensus(&self) -> &Consensus {
+        &self.consensus
+    }
+}
+
+impl ChainExt for MockRunningChain {
+    fn client_storage(&self) -> &Storage {
+        &self.storage
+    }
+
+    fn consensus(&self) -> &Consensus {
+        &self.shared.consensus()
+    }
+}
+
+impl RunningChainExt for MockRunningChain {
+    fn controller(&self) -> &ChainController {
+        &self.chain_controller
+    }
+
+    fn shared(&self) -> &Shared {
+        &self.shared
+    }
+}
+
+impl MockChain {
+    pub(crate) fn new(resource: &Resource, prefix: &str) -> Self {
+        let tmp_dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
+        let storage = Storage::new(tmp_dir.path().to_str().unwrap());
+        let chain_spec = ChainSpec::load_from(resource).expect("load spec should be OK");
+        let consensus = chain_spec
+            .build_consensus()
+            .expect("build consensus should be OK");
+        storage.init_genesis_block(consensus.genesis_block().data());
+        MockChain { storage, consensus }
+    }
+
+    pub(crate) fn new_with_default_pow(prefix: &str) -> Self {
+        // TODO Replace this to a devchain with "EaglesongBlake2b" pow.
+        let resource = Resource::bundled("specs/testnet.toml".to_owned());
+        Self::new(&resource, prefix)
+    }
+
+    pub(crate) fn new_with_dummy_pow(prefix: &str) -> Self {
+        let resource = Resource::file_system("src/tests/specs/dummy_pow.toml".into());
+        Self::new(&resource, prefix)
+    }
+
+    pub(crate) fn start(self) -> MockRunningChain {
+        let Self { storage, consensus } = self;
+
+        let config = BlockAssemblerConfig {
+            code_hash: h256!("0x0"),
+            args: Default::default(),
+            hash_type: ScriptHashType::Data,
+            message: Default::default(),
+            use_binary_version_as_message_prefix: true,
+            binary_version: "LightClient".to_string(),
+            update_interval_millis: 800,
+            notify: vec![],
+            notify_scripts: vec![],
+            notify_timeout_millis: 800,
+        };
+
+        let (shared, mut pack) = SharedBuilder::with_temp_db()
+            .consensus(consensus)
+            .block_assembler_config(Some(config))
+            .build()
+            .unwrap();
+
+        let network = dummy_network(&shared);
+        pack.take_tx_pool_builder().start(network);
+
+        let chain_service = ChainService::new(shared.clone(), pack.take_proposal_table());
+        let chain_controller = chain_service.start::<&str>(None);
+
+        MockRunningChain {
+            storage,
+            chain_controller,
+            shared,
+        }
+    }
+}
+
+fn dummy_network(shared: &Shared) -> NetworkController {
+    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let config = NetworkConfig {
+        max_peers: 19,
+        max_outbound_peers: 5,
+        path: tmp_dir.path().to_path_buf(),
+        ping_interval_secs: 15,
+        ping_timeout_secs: 20,
+        connect_outbound_interval_secs: 1,
+        discovery_local_address: true,
+        bootnode_mode: true,
+        reuse_port_on_linux: true,
+        ..Default::default()
+    };
+    let network_state =
+        Arc::new(NetworkState::from_config(config).expect("Init network state failed"));
+    NetworkService::new(
+        network_state,
+        vec![],
+        vec![],
+        shared.consensus().identify_name(),
+        "test".to_string(),
+        DefaultExitHandler::default(),
+    )
+    .start(shared.async_handle())
+    .expect("Start network service failed")
+}

--- a/src/tests/utils/mod.rs
+++ b/src/tests/utils/mod.rs
@@ -1,0 +1,5 @@
+mod chain;
+mod network_context;
+
+pub(crate) use chain::MockChain;
+pub(crate) use network_context::MockNetworkContext;

--- a/src/tests/verify.rs
+++ b/src/tests/verify.rs
@@ -1,30 +1,20 @@
 use std::collections::HashMap;
 
-use ckb_chain_spec::{consensus::Consensus, ChainSpec};
 use ckb_jsonrpc_types::{Block, Script, Transaction};
-use ckb_resource::Resource;
 use ckb_types::packed;
 
 use crate::{
-    storage::{Storage, StorageWithLastHeaders},
+    storage::StorageWithLastHeaders,
+    tests::{prelude::*, utils::MockChain},
     verify::verify_tx,
 };
 
-pub fn setup(prefix: &str) -> (Storage, Consensus) {
-    let tmp_dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-    let storage = Storage::new(tmp_dir.path().to_str().unwrap());
-    let chain_spec = ChainSpec::load_from(&Resource::bundled("specs/testnet.toml".to_string()))
-        .expect("load spec should be OK");
-    let consensus = chain_spec
-        .build_consensus()
-        .expect("build consensus should be OK");
-    storage.init_genesis_block(consensus.genesis_block().data());
-    (storage, consensus)
-}
-
 #[test]
 fn verify_valid_transaction() {
-    let (storage, consensus) = setup("verify_valid_transaction");
+    let chain = MockChain::new_with_default_pow("verify_valid_transaction");
+    let storage = chain.client_storage();
+    let consensus = chain.consensus();
+
     // https://pudge.explorer.nervos.org/address/ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq0l2z2v9305wm7rs5gqrpsf507ey8wj3tggtl4sj
     let script: packed::Script = serde_json::from_str::<Script>(r#"{"code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type": "type","args": "0xff5094c2c5f476fc38510018609a3fd921dd28ad"}"#).unwrap().into();
     let mut scripts = HashMap::new();
@@ -38,15 +28,18 @@ fn verify_valid_transaction() {
     // https://pudge.explorer.nervos.org/transaction/0xf34f4eaac4a662927fb52d4cb608e603150b9e0678a0f5ed941e3cfd5b68fb30
     let transaction: packed::Transaction = serde_json::from_str::<Transaction>(r#"{"cell_deps":[{"dep_type":"dep_group","out_point":{"index":"0x0","tx_hash":"0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37"}}],"header_deps":[],"inputs":[{"previous_output":{"index":"0x7","tx_hash":"0x8f8c79eb6671709633fe6a46de93c0fedc9c1b8a6527a18d3983879542635c9f"},"since":"0x0"}],"outputs":[{"capacity":"0x470de4df820000","lock":{"args":"0xff5094c2c5f476fc38510018609a3fd921dd28ad","code_hash":"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type":"type"},"type":null},{"capacity":"0xb61134e5a35e800","lock":{"args":"0x64257f00b6b63e987609fa9be2d0c86d351020fb","code_hash":"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type":"type"},"type":null}],"outputs_data":["0x","0x"],"version":"0x0","witnesses":["0x5500000010000000550000005500000041000000af34b54bebf8c5971da6a880f2df5a186c3f8d0b5c9a1fe1a90c95b8a4fb89ef3bab1ccec13797dcb3fee80400f953227dd7741227e08032e3598e16ccdaa49c00"]}"#).unwrap().into();
 
-    let swl = StorageWithLastHeaders::new(storage, Default::default());
+    let swl = StorageWithLastHeaders::new(storage.to_owned(), Default::default());
     let result = verify_tx(transaction.into_view(), &swl, &consensus).unwrap();
     assert_eq!(1682789, result);
 }
 
 #[test]
 fn non_contextual_transaction_verifier() {
-    let (storage, consensus) = setup("non_contextual_transaction_verifier");
-    let swl = StorageWithLastHeaders::new(storage, Default::default());
+    let chain = MockChain::new_with_default_pow("non_contextual_transaction_verifier");
+    let storage = chain.client_storage();
+    let consensus = chain.consensus();
+    let swl = StorageWithLastHeaders::new(storage.to_owned(), Default::default());
+
     // duplicate cell deps base on a valid transaction
     // https://pudge.explorer.nervos.org/transaction/0xf34f4eaac4a662927fb52d4cb608e603150b9e0678a0f5ed941e3cfd5b68fb30
     let transaction: packed::Transaction = serde_json::from_str::<Transaction>(r#"{"cell_deps":[{"dep_type":"dep_group","out_point":{"index":"0x0","tx_hash":"0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37"}}, {"dep_type":"dep_group","out_point":{"index":"0x0","tx_hash":"0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37"}}],"header_deps":[],"inputs":[{"previous_output":{"index":"0x7","tx_hash":"0x8f8c79eb6671709633fe6a46de93c0fedc9c1b8a6527a18d3983879542635c9f"},"since":"0x0"}],"outputs":[{"capacity":"0x470de4df820000","lock":{"args":"0xff5094c2c5f476fc38510018609a3fd921dd28ad","code_hash":"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type":"type"},"type":null},{"capacity":"0xb61134e5a35e800","lock":{"args":"0x64257f00b6b63e987609fa9be2d0c86d351020fb","code_hash":"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type":"type"},"type":null}],"outputs_data":["0x","0x"],"version":"0x0","witnesses":["0x5500000010000000550000005500000041000000af34b54bebf8c5971da6a880f2df5a186c3f8d0b5c9a1fe1a90c95b8a4fb89ef3bab1ccec13797dcb3fee80400f953227dd7741227e08032e3598e16ccdaa49c00"]}"#).unwrap().into();


### PR DESCRIPTION
### Notes

- At first, I write unit tests on my local machine (Linux, Intel CPU, Laptop) very smoothly.

  I introduced few crates such as `ckb-chain` for unit tests, so I upgraded `ckb-rocksdb`.

- But when I pushed request to the develop branch, the CI failed since unknown instructions in MacOS.

- I have to introduce the `rocksdb/portable` feature into `Cargo.toml`, then SIGSEGV occurred frequently even that feature is not used on my local machine.

  And, SIGSEGV occurred very frequently when running unit tests to generate coverage.

  _I couldn't figure out why and how to fix that._

  But I found that SIGSEGV occurred **LESS frequently** when using source-based coverage instead of gcov-based coverage.

  <details><summary>Click HERE to see more details about the SIGSEGV issue.</summary>

  ![image](https://user-images.githubusercontent.com/30993023/191895937-3cbaa36b-a63e-4fc7-8573-1f21d38b1c79.png)

  </details>