### PR TITLE
fix: check reorg blocks

### DIFF
--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -501,13 +501,13 @@ pub(crate) fn check_if_response_is_matched(
 
     let (sampled_count, last_n_count) = if total_count - reorg_count > last_n_blocks {
         let difficulty_boundary: U256 = prev_request.difficulty_boundary().unpack();
-        let sampled_count = headers
+        let before_boundary_count = headers
             .iter()
             .take_while(|h| h.total_difficulty() < difficulty_boundary)
             .count();
-        let last_n_count = total_count - reorg_count - sampled_count;
+        let last_n_count = total_count - before_boundary_count;
         if last_n_count > last_n_blocks {
-            (sampled_count, last_n_count)
+            (before_boundary_count - reorg_count, last_n_count)
         } else {
             (total_count - reorg_count - last_n_blocks, last_n_blocks)
         }

--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -122,22 +122,6 @@ impl<'a> SendLastStateProofProcess<'a> {
             false
         };
 
-        // The last header in `reorg_last_n_headers` should be continuous.
-        if reorg_count != 0 {
-            let last_reorg_header = &headers[reorg_count - 1];
-            let start_number: BlockNumber = original_request.get_content().start_number().unpack();
-            if last_reorg_header.number() != start_number - 1 {
-                let errmsg = format!(
-                    "failed to verify reorg last n headers \
-                    since they end at block#{} (hash: {:#x}) but we expect block#{}",
-                    last_reorg_header.number(),
-                    last_reorg_header.hash(),
-                    start_number - 1,
-                );
-                return StatusCode::InvalidReorgHeaders.with_context(errmsg);
-            }
-        }
-
         // Check parent hashes for the continuous headers.
         if reorg_count != 0 {
             return_if_failed!(check_continuous_headers(&headers[..reorg_count - 1]));
@@ -475,6 +459,7 @@ impl EpochDifficultyTrendDetails {
 }
 
 // Check if the response is matched the last request.
+// - Check reorg blocks if there has any.
 // - Check the difficulties.
 // - Check the difficulty boundary.
 pub(crate) fn check_if_response_is_matched(
@@ -498,6 +483,37 @@ pub(crate) fn check_if_response_is_matched(
         .iter()
         .take_while(|h| h.header().number() < start_number)
         .count();
+
+    if reorg_count != 0 {
+        // The count of reorg blocks should be `last_n_blocks`, unless the blocks are not enough.
+        if reorg_count != last_n_blocks {
+            let first_reorg_header = headers[0].header();
+            // Genesis block doesn't have chain root, so blocks should be started from 1.
+            if first_reorg_header.number() != 1 {
+                let errmsg = format!(
+                    "failed to verify reorg last n headers since the count (={}) should be {} \
+                    or the number(={}) of the first reorg block (hash: {:#x}) should 1,",
+                    reorg_count,
+                    last_n_blocks,
+                    first_reorg_header.number(),
+                    first_reorg_header.hash()
+                );
+                return Err(StatusCode::InvalidReorgHeaders.with_context(errmsg));
+            }
+        }
+        // The last header in `reorg_last_n_headers` should be continuous.
+        let last_reorg_header = headers[reorg_count - 1].header();
+        if last_reorg_header.number() != start_number - 1 {
+            let errmsg = format!(
+                "failed to verify reorg last n headers \
+                since they end at block#{} (hash: {:#x}) but we expect block#{}",
+                last_reorg_header.number(),
+                last_reorg_header.hash(),
+                start_number - 1,
+            );
+            return Err(StatusCode::InvalidReorgHeaders.with_context(errmsg));
+        }
+    }
 
     let (sampled_count, last_n_count) = if total_count - reorg_count > last_n_blocks {
         let difficulty_boundary: U256 = prev_request.difficulty_boundary().unpack();

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -123,6 +123,7 @@ pub(crate) trait RunningChainExt: ChainExt {
 
     fn build_prove_request(
         &self,
+        start_num: BlockNumber,
         last_num: BlockNumber,
         sampled_nums: &[BlockNumber],
         boundary_num: BlockNumber,
@@ -134,7 +135,9 @@ pub(crate) trait RunningChainExt: ChainExt {
             .expect("block stored")
             .into();
         let content = {
-            let genesis_block = self.consensus().genesis_block();
+            let start_header = snapshot
+                .get_header_by_number(start_num)
+                .expect("block stored");
             let difficulties = {
                 let u256_one = &U256::from(1u64);
                 let total_diffs = (0..last_num)
@@ -155,8 +158,8 @@ pub(crate) trait RunningChainExt: ChainExt {
                 .unwrap();
             packed::GetLastStateProof::new_builder()
                 .last_hash(last_header.header().hash())
-                .start_hash(genesis_block.hash())
-                .start_number(genesis_block.number().pack())
+                .start_hash(start_header.hash())
+                .start_number(start_header.number().pack())
                 .last_n_blocks(last_n_blocks.pack())
                 .difficulty_boundary(difficulty_boundary.pack())
                 .difficulties(difficulties.pack())

--- a/src/tests/protocols/light_client/send_last_state_proof.rs
+++ b/src/tests/protocols/light_client/send_last_state_proof.rs
@@ -6,7 +6,7 @@ use ckb_types::{
 };
 
 use crate::{
-    protocols::{LastState, Peers, ProveRequest, StatusCode},
+    protocols::{LastState, Peers, ProveRequest, ProveState, StatusCode},
     tests::{
         prelude::*,
         utils::{MockChain, MockNetworkContext},
@@ -325,6 +325,7 @@ async fn valid_proof_with_boundary_not_in_last_n() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -415,6 +416,7 @@ async fn valid_proof_with_boundary_in_last_n() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -481,6 +483,244 @@ async fn valid_proof_with_boundary_in_last_n() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_with_prove_state() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 30;
+    chain.mine_to(30);
+
+    let snapshot = chain.shared().snapshot();
+
+    let prev_last_number = 15;
+    let prev_sampled_numbers = vec![3, 4, 7, 10];
+    let sampled_numbers = vec![17, 20, 22, 25, 28];
+    let boundary_number = num - protocol.last_n_blocks() + 1;
+
+    // Setup the test fixture.
+    {
+        let prev_boundary_number = prev_last_number - protocol.last_n_blocks() + 1;
+        let prev_prove_request = chain.build_prove_request(
+            0,
+            prev_last_number,
+            &prev_sampled_numbers,
+            prev_boundary_number,
+            protocol.last_n_blocks(),
+        );
+        let prove_state = {
+            let prev_last_n_blocks_start_number = if prev_last_number > protocol.last_n_blocks() + 1
+            {
+                prev_last_number - protocol.last_n_blocks()
+            } else {
+                1
+            };
+            let last_n_headers = (prev_last_n_blocks_start_number..prev_last_number)
+                .into_iter()
+                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
+                .collect::<Vec<_>>();
+            ProveState::new_from_request(prev_prove_request, Vec::new(), last_n_headers)
+        };
+        protocol.commit_prove_state(peer_index, prove_state);
+        let mut prove_request = chain.build_prove_request(
+            prev_last_number,
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = sampled_numbers
+                .iter()
+                .map(|n| *n as BlockNumber)
+                .filter(|n| *n < first_last_n_number)
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        let last_header: VerifiableHeader = last_header.into();
+        assert!(prove_state.is_same_as(&last_header));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_with_reorg_blocks() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.set_last_n_blocks(3);
+
+    let num = 30;
+    chain.mine_to(30);
+
+    let snapshot = chain.shared().snapshot();
+
+    let prev_last_number = 15;
+    let prev_sampled_numbers = vec![3, 4, 7, 10];
+    let sampled_numbers = vec![17, 20, 22, 25, 28];
+    let boundary_number = num - protocol.last_n_blocks() + 1;
+
+    // Setup the test fixture.
+    {
+        let prev_boundary_number = prev_last_number - protocol.last_n_blocks() + 1;
+        let prev_prove_request = chain.build_prove_request(
+            0,
+            prev_last_number,
+            &prev_sampled_numbers,
+            prev_boundary_number,
+            protocol.last_n_blocks(),
+        );
+        let prove_state = {
+            let prev_last_n_blocks_start_number = if prev_last_number > protocol.last_n_blocks() + 1
+            {
+                prev_last_number - protocol.last_n_blocks()
+            } else {
+                1
+            };
+            let last_n_headers = (prev_last_n_blocks_start_number..prev_last_number)
+                .into_iter()
+                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
+                .collect::<Vec<_>>();
+            ProveState::new_from_request(prev_prove_request, Vec::new(), last_n_headers)
+        };
+        protocol.commit_prove_state(peer_index, prove_state);
+        let mut prove_request = chain.build_prove_request(
+            prev_last_number,
+            num,
+            &sampled_numbers,
+            boundary_number,
+            protocol.last_n_blocks(),
+        );
+        prove_request.skip_check_tau();
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let data = {
+            let reorg_start_number = if prev_last_number > protocol.last_n_blocks() + 1 {
+                prev_last_number - protocol.last_n_blocks()
+            } else {
+                1
+            };
+            let first_last_n_number = cmp::min(boundary_number, num - protocol.last_n_blocks());
+            let headers = (reorg_start_number..prev_last_number)
+                .chain(
+                    sampled_numbers
+                        .iter()
+                        .map(|n| *n as BlockNumber)
+                        .filter(|n| *n < first_last_n_number),
+                )
+                .chain((first_last_n_number..num).into_iter())
+                .map(|n| {
+                    snapshot
+                        .get_verifiable_header_by_number(n)
+                        .expect("block stored")
+                })
+                .collect::<Vec<_>>();
+            let proof = {
+                let last_number: BlockNumber = last_header.header().raw().number().unpack();
+                let numbers = headers
+                    .iter()
+                    .map(|header| header.header().raw().number().unpack())
+                    .collect::<Vec<BlockNumber>>();
+                chain.build_proof_by_numbers(last_number, &numbers)
+            };
+            let content = packed::SendLastStateProof::new_builder()
+                .last_header(last_header.clone())
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+
+        let prove_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state")
+            .get_prove_state()
+            .expect("has prove state")
+            .to_owned();
+        let last_header: VerifiableHeader = last_header.into();
+        assert!(prove_state.is_same_as(&last_header));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn invalid_proof() {
     let chain = MockChain::new_with_dummy_pow("test-light-client").start();
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);
@@ -505,6 +745,7 @@ async fn invalid_proof() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -588,6 +829,7 @@ async fn samples_are_incorrect() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -670,6 +912,7 @@ async fn samples_are_redundant() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -752,6 +995,7 @@ async fn samples_are_not_enough_1() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -833,6 +1077,7 @@ async fn samples_are_not_enough_2() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,
@@ -914,6 +1159,7 @@ async fn last_n_headers_should_be_continuous() {
     // Setup the test fixture.
     {
         let mut prove_request = chain.build_prove_request(
+            0,
             num,
             &sampled_numbers,
             boundary_number,


### PR DESCRIPTION
Commits:
- fix: subtract with overflow since the reorg blocks also are less than the boundary
  The unit test "valid_proof_with_reorg_blocks" will be panicked before this fix.
- feat: check the count of reorg blocks
  The count of reorg blocks should be `last_n_blocks`, unless the blocks are not enough.