### PR TITLE
feat: save matched filter blocks to storage

### DIFF
--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -1,7 +1,10 @@
 use super::{components, BAD_MESSAGE_BAN_TIME};
-use crate::protocols::{Peers, Status, StatusCode};
+use crate::protocols::{Peers, Status, StatusCode, GET_BLOCKS_PROOF_LIMIT};
 use crate::storage::Storage;
-use ckb_network::{async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
+use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
+use ckb_network::{
+    async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex, SupportProtocols,
+};
 use ckb_types::{core::BlockNumber, packed, prelude::*};
 use golomb_coded_set::{GCSFilterReader, SipHasher24Builder, M, P};
 use log::{debug, error, info, trace, warn};
@@ -111,6 +114,106 @@ impl FilterProtocol {
             _ => StatusCode::UnexpectedProtocolMessage.into(),
         }
     }
+
+    pub(crate) fn send_get_block_filters(
+        &self,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+        peer: PeerIndex,
+        start_number: u64,
+    ) {
+        let content = packed::GetBlockFilters::new_builder()
+            .start_number(start_number.pack())
+            .build();
+        let message = packed::BlockFilterMessage::new_builder()
+            .set(content)
+            .build();
+        if let Err(err) = nc.send_message_to(peer, message.as_bytes()) {
+            let error_message = format!("nc.send_message BlockFilterMessage, error: {:?}", err);
+            error!("{}", error_message);
+        }
+    }
+
+    pub(crate) fn prove_or_download_matched_blocks(
+        &self,
+        peer: PeerIndex,
+        nc: Arc<dyn CKBProtocolContext + Sync>,
+    ) {
+        let peer_state = if let Some(peer_state) = self.peers.get_state(&peer) {
+            peer_state
+        } else {
+            info!("ignoring, peer {} is disconnected", peer);
+            return;
+        };
+        if peer_state.get_blocks_proof_request().is_some() {
+            info!("peer {} has an inflight GetBlocksProof request", peer);
+        } else {
+            let blocks_to_prove = self
+                .peers
+                .get_matched_blocks_to_prove(GET_BLOCKS_PROOF_LIMIT);
+            if !blocks_to_prove.is_empty() {
+                debug!(
+                    "send get blocks proof request to peer: {}, count={}",
+                    peer,
+                    blocks_to_prove.len()
+                );
+                let prove_state_block_hash = if let Some(hash) = peer_state
+                    .get_prove_state()
+                    .map(|prove_state| prove_state.get_last_header().header().hash())
+                {
+                    hash
+                } else {
+                    warn!("ignoring, peer {} prove state is none", peer);
+                    return;
+                };
+                let content = packed::GetBlocksProof::new_builder()
+                    .block_hashes(blocks_to_prove.pack())
+                    .last_hash(prove_state_block_hash)
+                    .build();
+                let message = packed::LightClientMessage::new_builder()
+                    .set(content.clone())
+                    .build()
+                    .as_bytes();
+                self.peers.update_blocks_proof_request(peer, Some(content));
+                if let Err(err) =
+                    nc.send_message(SupportProtocols::LightClient.protocol_id(), peer, message)
+                {
+                    let error_message =
+                        format!("nc.send_message LightClientMessage, error: {:?}", err);
+                    error!("{}", error_message);
+                }
+            }
+        }
+
+        if peer_state.get_blocks_request().is_some() {
+            info!("peer {} has an inflight GetBlocks request", peer);
+        } else {
+            let blocks_to_download = self
+                .peers
+                .get_matched_blocks_to_download(INIT_BLOCKS_IN_TRANSIT_PER_PEER);
+            if !blocks_to_download.is_empty() {
+                debug!(
+                    "send get blocks request to peer: {}, count={}",
+                    peer,
+                    blocks_to_download.len()
+                );
+                self.peers
+                    .update_blocks_request(peer, Some(blocks_to_download.clone()));
+                let content = packed::GetBlocks::new_builder()
+                    .block_hashes(blocks_to_download.pack())
+                    .build();
+                let message = packed::SyncMessage::new_builder()
+                    .set(content)
+                    .build()
+                    .as_bytes();
+                if let Err(err) =
+                    nc.send_message(SupportProtocols::Sync.protocol_id(), peer, message)
+                {
+                    let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
+                    error!("{}", error_message);
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -179,9 +282,8 @@ impl CKBProtocolHandler for FilterProtocol {
     async fn notify(&mut self, nc: Arc<dyn CKBProtocolContext + Sync>, token: u64) {
         match token {
             GET_BLOCK_FILTERS_TOKEN => {
-                if let Some((peer, prove_state)) = self
-                    .peers
-                    .get_peers_which_are_proved()
+                let proved_peers = self.peers.get_peers_which_are_proved();
+                if let Some((peer, prove_state)) = proved_peers
                     .iter()
                     .max_by_key(|(_, prove_state)| prove_state.get_last_header().total_difficulty())
                 {
@@ -193,20 +295,25 @@ impl CKBProtocolHandler for FilterProtocol {
                         start_number,
                         prove_state.get_last_header().header().number()
                     );
-                    if self.pending_peer.should_ask() && prove_state_number >= start_number {
-                        let content = packed::GetBlockFilters::new_builder()
-                            .start_number(start_number.pack())
-                            .build();
-
-                        let message = packed::BlockFilterMessage::new_builder()
-                            .set(content)
-                            .build();
-
-                        if let Err(err) = nc.send_message_to(*peer, message.as_bytes()) {
-                            let error_message =
-                                format!("nc.send_message BlockFilterMessage, error: {:?}", err);
-                            error!("{}", error_message);
+                    if let Some((start_number, blocks_count, matched_blocks)) =
+                        self.pending_peer.storage.get_matched_blocks()
+                    {
+                        if self.peers.matched_blocks_is_empty() {
+                            debug!(
+                                "recover matched blocks from storage, start_number={}, blocks_count={}, matched_count: {}",
+                                start_number, blocks_count,
+                                matched_blocks.len(),
+                            );
+                            // recover matched blocks from storage
+                            self.peers.add_matched_blocks(matched_blocks);
+                            self.prove_or_download_matched_blocks(*peer, Arc::clone(&nc));
                         }
+                    } else if self.pending_peer.should_ask() && prove_state_number >= start_number {
+                        debug!(
+                            "send get block filters to {}, start_number={}",
+                            peer, start_number
+                        );
+                        self.send_get_block_filters(Arc::clone(&nc), *peer, start_number);
                     }
                 } else {
                     debug!("cannot find peers which are proved");

--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -2,6 +2,7 @@ use super::{components, BAD_MESSAGE_BAN_TIME};
 use crate::protocols::{Peers, Status, StatusCode};
 use crate::storage::Storage;
 use crate::utils::network::prove_or_download_matched_blocks;
+use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
 use ckb_network::{async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_types::{core::BlockNumber, packed, prelude::*};
 use golomb_coded_set::{GCSFilterReader, SipHasher24Builder, M, P};
@@ -224,11 +225,13 @@ impl CKBProtocolHandler for FilterProtocol {
                             );
                             // recover matched blocks from storage
                             self.peers.add_matched_blocks(&mut matched_blocks, blocks);
+                            let tip_header = self.pending_peer.storage.get_tip_header();
                             prove_or_download_matched_blocks(
                                 Arc::clone(&self.peers),
+                                &tip_header,
                                 &matched_blocks,
-                                *peer,
                                 nc.as_ref(),
+                                INIT_BLOCKS_IN_TRANSIT_PER_PEER,
                             );
                         }
                     } else if self.pending_peer.should_ask() && prove_state_number >= start_number {

--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -191,7 +191,7 @@ impl FilterProtocol {
         } else {
             let blocks_to_download = self
                 .peers
-                .get_matched_blocks_to_download(&matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
+                .get_matched_blocks_to_download(matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
             if !blocks_to_download.is_empty() {
                 debug!(
                     "send get blocks request to peer: {}, count={}",

--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -191,7 +191,7 @@ impl FilterProtocol {
         } else {
             let blocks_to_download = self
                 .peers
-                .get_matched_blocks_to_download(matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
+                .get_matched_blocks_to_download(&matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
             if !blocks_to_download.is_empty() {
                 debug!(
                     "send get blocks request to peer: {}, count={}",

--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -109,6 +109,7 @@ impl<'a> BlockFiltersProcess<'a> {
                 );
                 self.filter
                     .prove_or_download_matched_blocks(self.peer, self.nc);
+                // NOTE must insert matched blocks in storage later
                 self.filter.pending_peer.storage.update_matched_blocks(
                     start_number,
                     actual_blocks_count as u64,

--- a/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/src/protocols/light_client/components/send_blocks_proof.rs
@@ -88,9 +88,17 @@ impl<'a> SendBlocksProofProcess<'a> {
         {
             let block_hashes: Vec<packed::Byte32> =
                 headers.iter().map(|header| header.hash()).collect();
-            self.protocol
-                .peers
-                .mark_matched_blocks_proved(&block_hashes);
+            {
+                let mut matched_blocks = self
+                    .protocol
+                    .peers()
+                    .matched_blocks()
+                    .write()
+                    .expect("poisoned");
+                self.protocol
+                    .peers
+                    .mark_matched_blocks_proved(&mut matched_blocks, &block_hashes);
+            }
 
             if peer_state.get_blocks_request().is_some() {
                 info!("peer {} has an inflight GetBlocks request", self.peer);

--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -13,7 +13,7 @@ use ckb_types::{
     },
     U256,
 };
-use log::{error, trace, warn};
+use log::{debug, error, trace, warn};
 
 use super::super::{
     peers::ProveRequest, prelude::*, LastState, LightClientProtocol, ProveState, Status, StatusCode,
@@ -197,7 +197,7 @@ impl<'a> SendLastStateProofProcess<'a> {
             self.protocol.commit_prove_state(self.peer, prove_state);
         }
 
-        trace!("block proof verify passed");
+        debug!("block proof verify passed for peer: {}", self.peer);
         Status::ok()
     }
 }

--- a/src/protocols/light_client/constant.rs
+++ b/src/protocols/light_client/constant.rs
@@ -2,11 +2,9 @@ use std::time::Duration;
 
 pub const REFRESH_PEERS_TOKEN: u64 = 0;
 pub const FETCH_HEADER_TX_TOKEN: u64 = 1;
+// notify token to send GetBlocksProof and GetBlocks for previously timeout requests
+pub const GET_IDLE_BLOCKS_TOKEN: u64 = 2;
 
 pub const REFRESH_PEERS_DURATION: Duration = Duration::from_secs(60);
 pub const FETCH_HEADER_TX_DURATION: Duration = Duration::from_secs(3);
-
-// Copy from ckb/util/light-client-protocol-server
-pub const GET_BLOCKS_PROOF_LIMIT: usize = 1000;
-// Copy from ckb/util/light-client-protocol-server
-pub const GET_TRANSACTIONS_PROOF_LIMIT: usize = 1000;
+pub const GET_IDLE_BLOCKS_DURATION: Duration = Duration::from_secs(3);

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -440,11 +440,12 @@ impl LightClientProtocol {
             .map(|(peer_index, _)| peer_index)
             .collect();
 
+        let matched_blocks = self.peers.matched_blocks().read().expect("poisoned");
         let last_hash = tip_header.calc_header_hash();
         loop {
             let block_hashes = self
                 .peers
-                .get_matched_blocks_to_prove(GET_BLOCKS_PROOF_LIMIT);
+                .get_matched_blocks_to_prove(&matched_blocks, GET_BLOCKS_PROOF_LIMIT);
             if block_hashes.is_empty() {
                 break;
             }
@@ -469,7 +470,7 @@ impl LightClientProtocol {
         loop {
             let block_hashes = self
                 .peers
-                .get_matched_blocks_to_download(INIT_BLOCKS_IN_TRANSIT_PER_PEER);
+                .get_matched_blocks_to_download(&matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
             if block_hashes.is_empty() {
                 break;
             }

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -440,6 +440,11 @@ impl LightClientProtocol {
             .map(|(peer_index, _)| peer_index)
             .collect();
 
+        if best_peers.is_empty() {
+            debug!("no peers found for get idle blocks");
+            return;
+        }
+
         let matched_blocks = self.peers.matched_blocks().read().expect("poisoned");
         let last_hash = tip_header.calc_header_hash();
         loop {

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -711,6 +711,20 @@ impl Peers {
             })
             .collect()
     }
+
+    pub(crate) fn get_best_proved_peers(&self, best_tip: &packed::Header) -> Vec<PeerIndex> {
+        self.get_peers_which_are_proved()
+            .into_iter()
+            .filter(|(_, prove_state)| {
+                Some(prove_state.get_last_header().header())
+                    .into_iter()
+                    .chain(prove_state.get_last_headers().iter())
+                    .chain(prove_state.get_reorg_last_headers().iter())
+                    .any(|header| header.data().as_slice() == best_tip.as_slice())
+            })
+            .map(|(peer_index, _)| peer_index)
+            .collect()
+    }
 }
 
 fn if_verifiable_headers_are_same(lhs: &VerifiableHeader, rhs: &VerifiableHeader) -> bool {

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -26,3 +26,8 @@ pub const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
 pub const MESSAGE_TIMEOUT: u64 = 60 * 1000;
 
 pub const LAST_N_BLOCKS: BlockNumber = 100;
+
+// Copy from ckb/util/light-client-protocol-server
+pub const GET_BLOCKS_PROOF_LIMIT: usize = 1000;
+// Copy from ckb/util/light-client-protocol-server
+pub const GET_TRANSACTIONS_PROOF_LIMIT: usize = 1000;

--- a/src/protocols/synchronizer.rs
+++ b/src/protocols/synchronizer.rs
@@ -1,3 +1,4 @@
+use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
 use ckb_network::{async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex};
 use ckb_types::{packed, prelude::*};
 use log::{info, trace, warn};
@@ -104,11 +105,13 @@ impl CKBProtocolHandler for SyncProtocol {
                     {
                         self.peers
                             .add_matched_blocks(&mut matched_blocks, db_blocks);
+                        let tip_header = self.storage.get_tip_header();
                         prove_or_download_matched_blocks(
                             Arc::clone(&self.peers),
+                            &tip_header,
                             &matched_blocks,
-                            peer,
                             nc.as_ref(),
+                            INIT_BLOCKS_IN_TRANSIT_PER_PEER,
                         );
                     }
                 }

--- a/src/protocols/synchronizer.rs
+++ b/src/protocols/synchronizer.rs
@@ -77,6 +77,9 @@ impl CKBProtocolHandler for SyncProtocol {
                         .expect("get matched blocks from storage");
                     let matched_blocks: HashSet<_> =
                         matched_blocks.into_iter().map(|(hash, _)| hash).collect();
+
+                    // NOTE must remove matched blocks in storage first
+                    self.storage.remove_matched_blocks();
                     let blocks = self.peers.clear_matched_blocks();
                     assert_eq!(blocks.len(), matched_blocks.len());
                     info!(
@@ -93,7 +96,6 @@ impl CKBProtocolHandler for SyncProtocol {
                     }
                     let filtered_block_number = start_number - 1 + blocks_count;
                     self.storage.update_block_number(filtered_block_number);
-                    self.storage.remove_matched_blocks();
 
                     // send next GetBlockFilters message
                     let content = packed::GetBlockFilters::new_builder()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -235,13 +235,30 @@ impl Storage {
     }
 
     /// when all blocks downloaded and inserted into storage call this function.
-    pub fn remove_matched_blocks(&self) {
-        let key = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
+    ///
+    /// # Panics
+    ///  when given start_number is not the smallest in storage
+    pub fn remove_matched_blocks(&self, start_number: u64) {
+        let key_prefix = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
+        let mode = IteratorMode::From(key_prefix.as_ref(), Direction::Forward);
+        let earliest_start_number = self
+            .db
+            .iterator(mode)
+            .take_while(|(key, _value)| key.starts_with(&key_prefix))
+            .map(|(key, _)| {
+                u64::from_be_bytes(key[key_prefix.len()..].try_into().expect("start_number"))
+            })
+            .next()
+            .expect("storage matched blocks exists");
+        assert_eq!(start_number, earliest_start_number);
+
+        let mut key = key_prefix.clone();
+        key.extend(start_number.to_be_bytes());
         self.db.delete(&key).expect("delete matched blocks");
     }
 
     /// the matched blocks must not empty
-    pub fn update_matched_blocks(
+    pub fn add_matched_blocks(
         &self,
         start_number: u64,
         blocks_count: u64,
@@ -249,9 +266,10 @@ impl Storage {
         matched_blocks: Vec<(Byte32, bool)>,
     ) {
         assert!(!matched_blocks.is_empty());
-        let key = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
-        let mut value = start_number.to_le_bytes().to_vec();
-        value.extend(&blocks_count.to_le_bytes());
+        let mut key = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
+        key.extend(start_number.to_be_bytes());
+
+        let mut value = blocks_count.to_le_bytes().to_vec();
         for (block_hash, proved) in matched_blocks {
             value.extend(block_hash.as_slice());
             let proved_value: u8 = if proved { 1 } else { 0 };
@@ -263,30 +281,20 @@ impl Storage {
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn get_matched_blocks(&self) -> Option<(u64, u64, Vec<(Byte32, bool)>)> {
-        let key = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
+    pub fn get_earliest_matched_blocks(&self) -> Option<(u64, u64, Vec<(Byte32, bool)>)> {
+        let key_prefix = Key::Meta(MATCHED_FILTER_BLOCKS_KEY).into_vec();
+        let mode = IteratorMode::From(key_prefix.as_ref(), Direction::Forward);
         self.db
-            .get_pinned(&key)
-            .expect("db get last state should be ok")
-            .map(|data| {
+            .iterator(mode)
+            .take_while(|(key, _value)| key.starts_with(&key_prefix))
+            .map(|(key, value)| {
                 let mut u64_bytes = [0u8; 8];
-                u64_bytes.copy_from_slice(&data[0..8]);
-                let start_number = u64::from_le_bytes(u64_bytes);
-                u64_bytes.copy_from_slice(&data[8..16]);
-                let blocks_count = u64::from_le_bytes(u64_bytes);
-                assert!((data.len() - 16) % 33 == 0);
-                let matched_len = (data.len() - 16) / 33;
-                let matched_blocks = (0..matched_len)
-                    .map(|i| {
-                        let offset = 16 + i * 33;
-                        let part = &data[offset..offset + 32];
-                        let hash = packed::Byte32Reader::from_slice_should_be_ok(part).to_entity();
-                        let proved = data[offset + 32] == 1;
-                        (hash, proved)
-                    })
-                    .collect::<Vec<_>>();
-                (start_number, blocks_count, matched_blocks)
+                u64_bytes.copy_from_slice(&key[key_prefix.len()..]);
+                let start_number = u64::from_be_bytes(u64_bytes);
+                let (blocks_count, blocks) = parse_matched_blocks(&value);
+                (start_number, blocks_count, blocks)
             })
+            .next()
     }
 
     pub fn get_tip_header(&self) -> Header {
@@ -874,6 +882,24 @@ fn append_key(
     encoded.extend_from_slice(&block_number.to_be_bytes());
     encoded.extend_from_slice(&tx_index.to_be_bytes());
     encoded.extend_from_slice(&io_index.to_be_bytes());
+}
+
+fn parse_matched_blocks(data: &[u8]) -> (u64, Vec<(Byte32, bool)>) {
+    let mut u64_bytes = [0u8; 8];
+    u64_bytes.copy_from_slice(&data[0..8]);
+    let blocks_count = u64::from_le_bytes(u64_bytes);
+    assert!((data.len() - 8) % 33 == 0);
+    let matched_len = (data.len() - 8) / 33;
+    let matched_blocks = (0..matched_len)
+        .map(|i| {
+            let offset = 8 + i * 33;
+            let part = &data[offset..offset + 32];
+            let hash = packed::Byte32Reader::from_slice_should_be_ok(part).to_entity();
+            let proved = data[offset + 32] == 1;
+            (hash, proved)
+        })
+        .collect::<Vec<_>>();
+    (blocks_count, matched_blocks)
 }
 
 // a helper fn extracts script fields raw data

--- a/src/subcmds.rs
+++ b/src/subcmds.rs
@@ -51,7 +51,7 @@ impl RunConfig {
         ];
 
         let peers = Arc::new(Peers::default());
-        let sync_protocol = SyncProtocol::new(storage.clone());
+        let sync_protocol = SyncProtocol::new(storage.clone(), Arc::clone(&peers));
         let relay_protocol = RelayProtocol::new(pending_txs.clone(), Arc::clone(&peers));
         let light_client: Box<dyn CKBProtocolHandler> = Box::new(LightClientProtocol::new(
             storage.clone(),

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -15,7 +15,9 @@ use ckb_types::{
 };
 
 use crate::{
-    protocols::{FilterProtocol, LastState, LightClientProtocol, Peers, ProveRequest},
+    protocols::{
+        FilterProtocol, LastState, LightClientProtocol, Peers, ProveRequest, SyncProtocol,
+    },
     storage::Storage,
     tests::ALWAYS_SUCCESS_BIN,
 };
@@ -76,6 +78,11 @@ pub(crate) trait ChainExt {
     fn create_filter_protocol(&self, peers: Arc<Peers>) -> FilterProtocol {
         let storage = self.client_storage().to_owned();
         FilterProtocol::new(storage, peers)
+    }
+
+    fn create_sync_protocol(&self, peers: Arc<Peers>) -> SyncProtocol {
+        let storage = self.client_storage().to_owned();
+        SyncProtocol::new(storage, peers)
     }
 }
 

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -394,29 +394,13 @@ async fn test_block_filter_ok_with_blocks_matched() {
             .set(content.clone())
             .build()
     };
-    let get_block_filters_message = {
-        let start_number: u64 = min_filtered_block_number + 1;
-        let content = packed::GetBlockFilters::new_builder()
-            .start_number((start_number + 1).pack())
-            .build();
-        packed::BlockFilterMessage::new_builder()
-            .set(content)
-            .build()
-    };
     assert_eq!(
         nc.sent_messages().borrow().clone(),
-        vec![
-            (
-                SupportProtocols::LightClient.protocol_id(),
-                peer_index,
-                get_blocks_proof_message.as_bytes()
-            ),
-            (
-                SupportProtocols::Filter.protocol_id(),
-                peer_index,
-                get_block_filters_message.as_bytes()
-            )
-        ]
+        vec![(
+            SupportProtocols::LightClient.protocol_id(),
+            peer_index,
+            get_blocks_proof_message.as_bytes()
+        )]
     );
 }
 

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -10,7 +10,7 @@ use ckb_types::{
     packed::{self, Script},
     prelude::*,
     utilities::merkle_mountain_range::VerifiableHeader,
-    H256,
+    H256, U256,
 };
 
 use crate::{
@@ -338,15 +338,19 @@ async fn test_block_filter_ok_with_blocks_matched() {
             .collect(),
     );
 
+    let header = HeaderBuilder::default()
+        .epoch(EpochNumberWithFraction::new(0, 0, 100).full_value().pack())
+        .number((proved_number).pack())
+        .build();
+    let tip_header =
+        VerifiableHeader::new(header.clone(), Default::default(), None, Default::default());
+    chain
+        .client_storage()
+        .update_last_state(&U256::one(), &tip_header.header().data());
+
     let peer_index = PeerIndex::new(3);
     let (peers, prove_state_block_hash) = {
-        let header = HeaderBuilder::default()
-            .epoch(EpochNumberWithFraction::new(0, 0, 100).full_value().pack())
-            .number((proved_number).pack())
-            .build();
         let prove_state_block_hash = header.hash();
-        let tip_header =
-            VerifiableHeader::new(header, Default::default(), None, Default::default());
         let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());
         let prove_state =
@@ -590,6 +594,9 @@ async fn test_block_filter_notify_recover_matched_blocks() {
         Default::default(),
     );
     let tip_hash = tip_header.header().hash();
+    chain
+        .client_storage()
+        .update_last_state(&U256::one(), &tip_header.header().data());
     let peers = {
         let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());

--- a/src/tests/protocols/light_client/mod.rs
+++ b/src/tests/protocols/light_client/mod.rs
@@ -162,7 +162,7 @@ fn build_prove_request_content() {
 
 #[tokio::test]
 async fn test_light_client_get_idle_matched_blocks() {
-    let chain = MockChain::new_with_dummy_pow("test-block-filter");
+    let chain = MockChain::new_with_dummy_pow("test-light-client");
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);
 
     let peer_index = PeerIndex::new(3);

--- a/src/tests/protocols/light_client/mod.rs
+++ b/src/tests/protocols/light_client/mod.rs
@@ -6,11 +6,14 @@ use ckb_types::{
     packed,
     prelude::*,
     utilities::{merkle_mountain_range::VerifiableHeader, DIFF_TWO},
-    U256,
+    H256, U256,
 };
 
 use crate::{
-    protocols::{PeerState, Peers, BAD_MESSAGE_BAN_TIME},
+    protocols::{
+        light_client::constant::GET_IDLE_BLOCKS_TOKEN, LastState, PeerState, Peers, ProveRequest,
+        ProveState, BAD_MESSAGE_BAN_TIME,
+    },
     tests::{
         prelude::*,
         utils::{MockChain, MockNetworkContext},
@@ -155,4 +158,79 @@ fn build_prove_request_content() {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn test_light_client_get_idle_matched_blocks() {
+    let chain = MockChain::new_with_dummy_pow("test-block-filter");
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(3);
+    let tip_header = VerifiableHeader::new(
+        HeaderBuilder::default()
+            .epoch(EpochNumberWithFraction::new(0, 0, 100).full_value().pack())
+            .number(3u64.pack())
+            .build(),
+        Default::default(),
+        None,
+        Default::default(),
+    );
+    chain
+        .client_storage()
+        .update_last_state(&U256::one(), &tip_header.header().data());
+    let tip_hash = tip_header.header().hash();
+    let peers = {
+        let last_state = LastState::new(tip_header);
+        let request = ProveRequest::new(last_state, Default::default());
+        let prove_state =
+            ProveState::new_from_request(request, Default::default(), Default::default());
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers.commit_prove_state(peer_index, prove_state);
+        peers
+    };
+    let unproved_block_hash = H256(rand::random()).pack();
+    let proved_block_hash = H256(rand::random()).pack();
+    let blocks = vec![
+        (unproved_block_hash.clone(), false),
+        (proved_block_hash.clone(), true),
+    ];
+    {
+        let mut matched_blocks = peers.matched_blocks().write().expect("poisoned");
+        peers.add_matched_blocks(&mut matched_blocks, blocks);
+    }
+
+    let mut protocol = chain.create_light_client_protocol(peers);
+    protocol.notify(nc.context(), GET_IDLE_BLOCKS_TOKEN).await;
+
+    let content = packed::GetBlocksProof::new_builder()
+        .block_hashes(vec![unproved_block_hash].pack())
+        .last_hash(tip_hash.clone())
+        .build();
+    let get_blocks_proof_message = packed::LightClientMessage::new_builder()
+        .set(content.clone())
+        .build()
+        .as_bytes();
+    let content = packed::GetBlocks::new_builder()
+        .block_hashes(vec![proved_block_hash].pack())
+        .build();
+    let get_blocks_message = packed::SyncMessage::new_builder()
+        .set(content.clone())
+        .build()
+        .as_bytes();
+    assert_eq!(
+        nc.sent_messages().borrow().clone(),
+        vec![
+            (
+                SupportProtocols::LightClient.protocol_id(),
+                peer_index,
+                get_blocks_proof_message,
+            ),
+            (
+                SupportProtocols::Sync.protocol_id(),
+                peer_index,
+                get_blocks_message,
+            )
+        ]
+    );
 }

--- a/src/tests/protocols/mod.rs
+++ b/src/tests/protocols/mod.rs
@@ -1,2 +1,3 @@
 mod block_filter;
 mod light_client;
+mod synchronizer;

--- a/src/tests/protocols/synchronizer.rs
+++ b/src/tests/protocols/synchronizer.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
+use ckb_types::{
+    core::BlockBuilder,
+    packed::{self, Script},
+    prelude::*,
+};
+
+use crate::{
+    protocols::Peers,
+    tests::{
+        prelude::*,
+        utils::{MockChain, MockNetworkContext},
+    },
+};
+
+#[tokio::test]
+async fn test_sync_add_block() {
+    let chain = MockChain::new_with_dummy_pow("test-sync");
+    let nc = MockNetworkContext::new(SupportProtocols::Sync);
+
+    let mut scripts = HashMap::new();
+    scripts.insert(Script::default(), 1);
+    chain.client_storage().update_filter_scripts(scripts);
+
+    let min_filtered_block_number = chain
+        .client_storage()
+        .get_filter_scripts()
+        .values()
+        .min()
+        .cloned()
+        .unwrap_or_default();
+    let start_number = min_filtered_block_number + 1;
+    let blocks_count = 1;
+    let block_view = BlockBuilder::default().build();
+    let proved_block_hash = block_view.hash();
+    chain.client_storage().update_matched_blocks(
+        start_number,
+        blocks_count,
+        vec![(proved_block_hash.clone(), true)],
+    );
+    let peer_index = PeerIndex::new(3);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        {
+            let mut matched_blocks = peers.matched_blocks().write().unwrap();
+            peers.add_matched_blocks(&mut matched_blocks, vec![(proved_block_hash, true)]);
+        }
+        peers
+    };
+
+    let message = {
+        let content = packed::SendBlock::new_builder()
+            .block(block_view.data())
+            .build();
+        packed::SyncMessage::new_builder()
+            .set(content)
+            .build()
+            .as_bytes()
+    };
+
+    let mut protocol = chain.create_sync_protocol(Arc::clone(&peers));
+    protocol.received(nc.context(), peer_index, message).await;
+
+    assert!(peers.matched_blocks().read().unwrap().is_empty());
+    assert!(chain.client_storage().get_matched_blocks().is_none());
+    assert!(nc.banned_peers().borrow().is_empty());
+    let get_block_filters_message = {
+        let storage_filtered_block_number = chain
+            .client_storage()
+            .get_filter_scripts()
+            .values()
+            .min()
+            .cloned()
+            .unwrap_or_default();
+        let filtered_block_number = start_number - 1 + blocks_count;
+        assert_eq!(storage_filtered_block_number, filtered_block_number);
+        let content = packed::GetBlockFilters::new_builder()
+            .start_number((filtered_block_number + 1).pack())
+            .build();
+        packed::BlockFilterMessage::new_builder()
+            .set(content)
+            .build()
+            .as_bytes()
+    };
+    assert_eq!(
+        nc.sent_messages().borrow().clone(),
+        vec![(
+            SupportProtocols::Filter.protocol_id(),
+            peer_index,
+            get_block_filters_message
+        )]
+    );
+}

--- a/src/tests/service.rs
+++ b/src/tests/service.rs
@@ -15,7 +15,6 @@ use ckb_types::{
     H256,
 };
 use dashmap::DashMap;
-use tempfile;
 
 use crate::{
     protocols::Peers,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod fs;
+pub(crate) mod network;

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -1,84 +1,108 @@
 use crate::protocols::{Peers, GET_BLOCKS_PROOF_LIMIT};
-use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
-use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
+use ckb_network::{CKBProtocolContext, SupportProtocols};
 use ckb_types::{packed, prelude::*, H256};
-use log::{debug, error, info, warn};
+use log::{debug, error};
+use rand::seq::SliceRandom;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(crate) fn prove_or_download_matched_blocks(
     peers: Arc<Peers>,
+    best_tip: &packed::Header,
     matched_blocks: &HashMap<H256, (bool, Option<packed::Block>)>,
-    peer: PeerIndex,
     nc: &dyn CKBProtocolContext,
+    init_blocks_in_transit_per_peer: usize,
 ) {
-    let peer_state = if let Some(peer_state) = peers.get_state(&peer) {
-        peer_state
-    } else {
-        info!("ignoring, peer {} is disconnected", peer);
-        return;
-    };
-    if peer_state.get_blocks_proof_request().is_some() {
-        info!("peer {} has an inflight GetBlocksProof request", peer);
-    } else {
-        let blocks_to_prove =
-            peers.get_matched_blocks_to_prove(matched_blocks, GET_BLOCKS_PROOF_LIMIT);
-        if !blocks_to_prove.is_empty() {
-            debug!(
-                "send get blocks proof request to peer: {}, count={}",
-                peer,
-                blocks_to_prove.len()
-            );
-            let prove_state_block_hash = if let Some(hash) = peer_state
-                .get_prove_state()
-                .map(|prove_state| prove_state.get_last_header().header().hash())
-            {
-                hash
+    let best_peers: Vec<_> = peers.get_best_proved_peers(best_tip);
+    let last_hash = best_tip.calc_header_hash();
+
+    loop {
+        if let Some(peer) = best_peers
+            .iter()
+            .filter(|peer| {
+                peers
+                    .get_state(peer)
+                    .map(|state| state.get_blocks_proof_request().is_none())
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>()
+            .choose(&mut rand::thread_rng())
+            .cloned()
+        {
+            let blocks_to_prove =
+                peers.get_matched_blocks_to_prove(matched_blocks, GET_BLOCKS_PROOF_LIMIT);
+            if !blocks_to_prove.is_empty() {
+                debug!(
+                    "send get blocks proof request to peer: {}, count={}",
+                    peer,
+                    blocks_to_prove.len()
+                );
+                let content = packed::GetBlocksProof::new_builder()
+                    .block_hashes(blocks_to_prove.pack())
+                    .last_hash(last_hash.clone())
+                    .build();
+                let message = packed::LightClientMessage::new_builder()
+                    .set(content.clone())
+                    .build()
+                    .as_bytes();
+                peers.update_blocks_proof_request(*peer, Some(content));
+                if let Err(err) =
+                    nc.send_message(SupportProtocols::LightClient.protocol_id(), *peer, message)
+                {
+                    let error_message =
+                        format!("nc.send_message LightClientMessage, error: {:?}", err);
+                    error!("{}", error_message);
+                }
             } else {
-                warn!("ignoring, peer {} prove state is none", peer);
-                return;
-            };
-            let content = packed::GetBlocksProof::new_builder()
-                .block_hashes(blocks_to_prove.pack())
-                .last_hash(prove_state_block_hash)
-                .build();
-            let message = packed::LightClientMessage::new_builder()
-                .set(content.clone())
-                .build()
-                .as_bytes();
-            peers.update_blocks_proof_request(peer, Some(content));
-            if let Err(err) =
-                nc.send_message(SupportProtocols::LightClient.protocol_id(), peer, message)
-            {
-                let error_message = format!("nc.send_message LightClientMessage, error: {:?}", err);
-                error!("{}", error_message);
+                break;
             }
+        } else {
+            debug!("all valid peers are busy for get blocks proof");
+            break;
         }
     }
 
-    if peer_state.get_blocks_request().is_some() {
-        info!("peer {} has an inflight GetBlocks request", peer);
-    } else {
-        let blocks_to_download =
-            peers.get_matched_blocks_to_download(matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
-        if !blocks_to_download.is_empty() {
-            debug!(
-                "send get blocks request to peer: {}, count={}",
-                peer,
-                blocks_to_download.len()
-            );
-            peers.update_blocks_request(peer, Some(blocks_to_download.clone()));
-            let content = packed::GetBlocks::new_builder()
-                .block_hashes(blocks_to_download.pack())
-                .build();
-            let message = packed::SyncMessage::new_builder()
-                .set(content)
-                .build()
-                .as_bytes();
-            if let Err(err) = nc.send_message(SupportProtocols::Sync.protocol_id(), peer, message) {
-                let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
-                error!("{}", error_message);
+    loop {
+        if let Some(peer) = best_peers
+            .iter()
+            .filter(|peer| {
+                peers
+                    .get_state(peer)
+                    .map(|state| state.get_blocks_request().is_none())
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>()
+            .choose(&mut rand::thread_rng())
+            .cloned()
+        {
+            let blocks_to_download = peers
+                .get_matched_blocks_to_download(matched_blocks, init_blocks_in_transit_per_peer);
+            if !blocks_to_download.is_empty() {
+                debug!(
+                    "send get blocks request to peer: {}, count={}",
+                    peer,
+                    blocks_to_download.len()
+                );
+                peers.update_blocks_request(*peer, Some(blocks_to_download.clone()));
+                let content = packed::GetBlocks::new_builder()
+                    .block_hashes(blocks_to_download.pack())
+                    .build();
+                let message = packed::SyncMessage::new_builder()
+                    .set(content)
+                    .build()
+                    .as_bytes();
+                if let Err(err) =
+                    nc.send_message(SupportProtocols::Sync.protocol_id(), *peer, message)
+                {
+                    let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
+                    error!("{}", error_message);
+                }
+            } else {
+                break;
             }
+        } else {
+            debug!("all valid peers are busy for get blocks");
+            break;
         }
     }
 }

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -1,0 +1,84 @@
+use crate::protocols::{Peers, GET_BLOCKS_PROOF_LIMIT};
+use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
+use ckb_network::{CKBProtocolContext, PeerIndex, SupportProtocols};
+use ckb_types::{packed, prelude::*, H256};
+use log::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub(crate) fn prove_or_download_matched_blocks(
+    peers: Arc<Peers>,
+    matched_blocks: &HashMap<H256, (bool, Option<packed::Block>)>,
+    peer: PeerIndex,
+    nc: &dyn CKBProtocolContext,
+) {
+    let peer_state = if let Some(peer_state) = peers.get_state(&peer) {
+        peer_state
+    } else {
+        info!("ignoring, peer {} is disconnected", peer);
+        return;
+    };
+    if peer_state.get_blocks_proof_request().is_some() {
+        info!("peer {} has an inflight GetBlocksProof request", peer);
+    } else {
+        let blocks_to_prove =
+            peers.get_matched_blocks_to_prove(matched_blocks, GET_BLOCKS_PROOF_LIMIT);
+        if !blocks_to_prove.is_empty() {
+            debug!(
+                "send get blocks proof request to peer: {}, count={}",
+                peer,
+                blocks_to_prove.len()
+            );
+            let prove_state_block_hash = if let Some(hash) = peer_state
+                .get_prove_state()
+                .map(|prove_state| prove_state.get_last_header().header().hash())
+            {
+                hash
+            } else {
+                warn!("ignoring, peer {} prove state is none", peer);
+                return;
+            };
+            let content = packed::GetBlocksProof::new_builder()
+                .block_hashes(blocks_to_prove.pack())
+                .last_hash(prove_state_block_hash)
+                .build();
+            let message = packed::LightClientMessage::new_builder()
+                .set(content.clone())
+                .build()
+                .as_bytes();
+            peers.update_blocks_proof_request(peer, Some(content));
+            if let Err(err) =
+                nc.send_message(SupportProtocols::LightClient.protocol_id(), peer, message)
+            {
+                let error_message = format!("nc.send_message LightClientMessage, error: {:?}", err);
+                error!("{}", error_message);
+            }
+        }
+    }
+
+    if peer_state.get_blocks_request().is_some() {
+        info!("peer {} has an inflight GetBlocks request", peer);
+    } else {
+        let blocks_to_download =
+            peers.get_matched_blocks_to_download(matched_blocks, INIT_BLOCKS_IN_TRANSIT_PER_PEER);
+        if !blocks_to_download.is_empty() {
+            debug!(
+                "send get blocks request to peer: {}, count={}",
+                peer,
+                blocks_to_download.len()
+            );
+            peers.update_blocks_request(peer, Some(blocks_to_download.clone()));
+            let content = packed::GetBlocks::new_builder()
+                .block_hashes(blocks_to_download.pack())
+                .build();
+            let message = packed::SyncMessage::new_builder()
+                .set(content)
+                .build()
+                .as_bytes();
+            if let Err(err) = nc.send_message(SupportProtocols::Sync.protocol_id(), peer, message) {
+                let error_message = format!("nc.send_message SyncMessage, error: {:?}", err);
+                error!("{}", error_message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
* Save matched filter blocks to storage before send `GetBlocksProof`/`GetBlocks` requests
* Send next `GetBlockFilters` request when previous matched filter blocks all downloaded
* If peer response `GetBlocksProof`/`GetBlocks` timeout, disconnect it
* Periodic if matched filter blocks have proved or downloaded, if not send corresponding to idle peer
