### PR TITLE
feat: handle missing items for a proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "ckb-app-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-build-info",
  "ckb-chain-spec",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "ckb-async-runtime"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-logger",
  "ckb-spawn",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "ckb-block-filter"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-channel",
  "ckb-logger",
@@ -395,12 +395,12 @@ dependencies = [
 [[package]]
 name = "ckb-build-info"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 
 [[package]]
 name = "ckb-chain"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "ckb-chain-spec"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-constant",
  "ckb-crypto",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "ckb-channel"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -454,12 +454,12 @@ dependencies = [
 [[package]]
 name = "ckb-constant"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 
 [[package]]
 name = "ckb-crypto"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "ckb-dao"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "ckb-dao-utils"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "ckb-db"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-db-schema",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "ckb-db-migration"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-db",
  "ckb-db-schema",
@@ -520,12 +520,12 @@ dependencies = [
 [[package]]
 name = "ckb-db-schema"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 
 [[package]]
 name = "ckb-error"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash-core"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "faster-hex",
  "serde",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash-macros"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "ckb-freezer"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-error",
  "ckb-logger",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "ckb-hash"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "ckb-jsonrpc-types"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-types",
  "faster-hex",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "ckb-launcher"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -705,7 +705,7 @@ dependencies = [
 [[package]]
 name = "ckb-light-client-protocol-server"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-logger",
  "ckb-merkle-mountain-range",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "log",
 ]
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "serde",
 ]
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger-service"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ansi_term",
  "backtrace",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "ckb-memory-tracker"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-db",
  "ckb-logger",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "ckb-metrics"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "opentelemetry",
 ]
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "ckb-metrics-config"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "serde",
 ]
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "ckb-migration-template"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "quote",
  "syn",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "ckb-multisig"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-crypto",
  "ckb-error",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "ckb-network"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "bitflags",
  "bloom-filters",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "ckb-network-alert"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-error",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "ckb-notify"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-channel",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity-core"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "serde",
 ]
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity-macros"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "ckb-pow"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "ckb-proposal-table"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-chain-spec",
  "ckb-logger",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "ckb-rational"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "ckb-resource"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "ckb-reward-calculator"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "ckb-rpc"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-chain",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "ckb-rust-unstable-port"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "is_sorted",
 ]
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "ckb-script"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ckb-shared"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "arc-swap",
  "ckb-async-runtime",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "ckb-snapshot"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "arc-swap",
  "ckb-chain-spec",
@@ -1075,12 +1075,12 @@ dependencies = [
 [[package]]
 name = "ckb-spawn"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 
 [[package]]
 name = "ckb-stop-handler"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-channel",
  "ckb-logger",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "ckb-store"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-chain-spec",
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "ckb-sync"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "bitflags",
  "ckb-app-config",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "ckb-traits"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-types",
 ]
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "ckb-tx-pool"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-app-config",
  "ckb-async-runtime",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "ckb-types"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "bit-vec",
  "bytes 1.1.0",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "ckb-util"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "linked-hash-map",
  "once_cell",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "ckb-verification"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-chain-spec",
  "ckb-dao",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "ckb-verification-contextual"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "ckb-async-runtime",
  "ckb-chain-spec",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "ckb-verification-traits"
 version = "0.105.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?rev=e976f2f2c3dfbabd257bfde1109ac327fd143579#e976f2f2c3dfbabd257bfde1109ac327fd143579"
+source = "git+https://github.com/nervosnetwork/ckb?rev=72dc307ffc53915db6ca4dc8470bf3b12511d4a0#72dc307ffc53915db6ca4dc8470bf3b12511d4a0"
 dependencies = [
  "bitflags",
  "ckb-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ homepage = "https://github.com/nervosnetwork/ckb-light-client"
 repository = "https://github.com/nervosnetwork/ckb-light-client"
 
 [dependencies]
-ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
+ckb-app-config    = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-async-runtime = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-constant      = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-types         = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-network       = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-jsonrpc-types = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-error         = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-script        = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-chain-spec    = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-traits        = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-resource      = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-verification  = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
 ckb-merkle-mountain-range = "0.5.1"
 golomb-coded-set = "0.2.0"
 rocksdb = { package = "ckb-rocksdb", version ="=0.18.3", features = ["snappy"] }
@@ -44,11 +44,11 @@ jsonrpc-http-server = "18.0"
 jsonrpc-server-utils = "18.0"
 
 [dev-dependencies]
-ckb-launcher    = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-shared      = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-chain       = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-tx-pool     = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
-ckb-store       = { git="https://github.com/nervosnetwork/ckb", rev = "e976f2f2c3dfbabd257bfde1109ac327fd143579" }
+ckb-launcher    = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-shared      = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-chain       = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-tx-pool     = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
+ckb-store       = { git="https://github.com/nervosnetwork/ckb", rev = "72dc307ffc53915db6ca4dc8470bf3b12511d4a0" }
 tempfile = "3.0"
 rand = "0.6"
 serde_json = "1.0"

--- a/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/src/protocols/light_client/components/send_blocks_proof.rs
@@ -52,12 +52,18 @@ impl<'a> SendBlocksProofProcess<'a> {
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
 
         // Update the last state if the response contains a new one.
-        if self.message.proof().is_empty() {
-            return_if_failed!(self.protocol.process_last_state(self.peer, last_header));
-            self.protocol
-                .peers()
-                .mark_fetching_headers_timeout(self.peer);
-            return Status::ok();
+        if original_request.last_hash() != last_header.header().hash() {
+            if self.message.proof().is_empty() && self.message.headers().is_empty() {
+                return_if_failed!(self.protocol.process_last_state(self.peer, last_header));
+                self.protocol
+                    .peers()
+                    .mark_fetching_headers_timeout(self.peer);
+                return Status::ok();
+            } else {
+                // Since the last state is different, then no data should be contained.
+                error!("peer {} send a proof with different last state", self.peer);
+                return StatusCode::UnexpectedResponse.into();
+            }
         }
 
         let headers: Vec<_> = self

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -199,6 +199,10 @@ impl BlocksProofRequest {
         Self { content, when_sent }
     }
 
+    pub(crate) fn last_hash(&self) -> packed::Byte32 {
+        self.content.last_hash()
+    }
+
     pub(crate) fn block_hashes(&self) -> Vec<H256> {
         self.content
             .block_hashes()
@@ -237,6 +241,10 @@ impl BlocksRequest {
 impl TransactionsProofRequest {
     fn new(content: packed::GetTransactionsProof, when_sent: u64) -> Self {
         Self { content, when_sent }
+    }
+
+    pub(crate) fn last_hash(&self) -> packed::Byte32 {
+        self.content.last_hash()
     }
 
     pub(crate) fn tx_hashes(&self) -> Vec<H256> {

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -208,6 +208,7 @@ pub(crate) trait RunningChainExt: ChainExt {
         &self,
         last_num: BlockNumber,
         block_nums: &[BlockNumber],
+        missing_block_hashes: &[packed::Byte32],
     ) -> packed::GetBlocksProof {
         let snapshot = self.shared().snapshot();
         let last_header = snapshot
@@ -221,6 +222,7 @@ pub(crate) trait RunningChainExt: ChainExt {
                     .expect("block stored")
                     .hash()
             })
+            .chain(missing_block_hashes.iter().map(ToOwned::to_owned))
             .collect::<Vec<_>>();
         packed::GetBlocksProof::new_builder()
             .last_hash(last_header.hash())

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -88,7 +88,7 @@ async fn test_block_filter_ignore_start_number() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert!(nc.sent_messages().borrow().is_empty());
 }
 
@@ -139,7 +139,7 @@ async fn test_block_filter_empty_filters() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert!(nc.sent_messages().borrow().is_empty());
 }
 
@@ -246,7 +246,7 @@ async fn test_block_filter_start_number_greater_then_proved_number() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert!(nc.sent_messages().borrow().is_empty());
 }
 
@@ -299,7 +299,7 @@ async fn test_block_filter_ok_with_blocks_not_matched() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
 
     let message = {
         let start_number: u64 = min_filtered_block_number + 1;
@@ -384,7 +384,7 @@ async fn test_block_filter_ok_with_blocks_matched() {
 
     let mut protocol = chain.create_filter_protocol(peers);
     protocol.received(nc.context(), peer_index, message).await;
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
 
     let get_blocks_proof_message = {
         let content = packed::GetBlocksProof::new_builder()

--- a/src/tests/protocols/light_client/send_blocks_proof.rs
+++ b/src/tests/protocols/light_client/send_blocks_proof.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
 use ckb_types::{
-    core::BlockNumber, packed, prelude::*, utilities::merkle_mountain_range::VerifiableHeader,
+    core::BlockNumber, h256, packed, prelude::*, utilities::merkle_mountain_range::VerifiableHeader,
 };
 
 use crate::{
@@ -113,7 +113,7 @@ async fn last_state_is_changed() {
                 .collect::<Vec<_>>();
             ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
         };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
+        let content = chain.build_blocks_proof_content(num, &block_numbers, &[]);
         protocol.peers().update_last_state(peer_index, last_state);
         protocol
             .peers()
@@ -205,7 +205,7 @@ async fn unexpected_response() {
                 .collect::<Vec<_>>();
             ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
         };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
+        let content = chain.build_blocks_proof_content(num, &block_numbers, &[]);
         protocol.peers().update_last_state(peer_index, last_state);
         protocol
             .peers()
@@ -251,233 +251,6 @@ async fn unexpected_response() {
 
         assert!(nc.banned_since(peer_index, StatusCode::UnexpectedResponse));
         assert!(nc.sent_messages().borrow().is_empty());
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn valid_proof() {
-    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
-    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
-
-    let peer_index = PeerIndex::new(1);
-    let peers = {
-        let peers = Arc::new(Peers::default());
-        peers.add_peer(peer_index);
-        peers
-    };
-    let mut protocol = chain.create_light_client_protocol(peers);
-
-    let num = 20;
-    chain.mine_to(20);
-
-    let snapshot = chain.shared().snapshot();
-
-    let block_numbers = vec![3, 5, 8, 11, 16, 18];
-
-    // Setup the test fixture.
-    {
-        let peer_state = protocol
-            .get_peer_state(&peer_index)
-            .expect("has peer state");
-        let prove_request = {
-            let last_header: VerifiableHeader = snapshot
-                .get_verifiable_header_by_number(num)
-                .expect("block stored")
-                .into();
-            let content = protocol
-                .build_prove_request_content(&peer_state, &last_header)
-                .expect("build prove request content");
-            let last_state = LastState::new(last_header);
-            protocol
-                .peers()
-                .update_last_state(peer_index, last_state.clone());
-            ProveRequest::new(last_state, content)
-        };
-        let last_state = LastState::new(prove_request.get_last_header().to_owned());
-        let prove_state = {
-            let last_n_blocks_start_number = if num > protocol.last_n_blocks() + 1 {
-                num - protocol.last_n_blocks()
-            } else {
-                1
-            };
-            let last_n_headers = (last_n_blocks_start_number..num)
-                .into_iter()
-                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
-                .collect::<Vec<_>>();
-            ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
-        };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
-        protocol.peers().update_last_state(peer_index, last_state);
-        protocol
-            .peers()
-            .update_prove_request(peer_index, Some(prove_request));
-        protocol.commit_prove_state(peer_index, prove_state);
-        protocol
-            .peers()
-            .update_blocks_proof_request(peer_index, Some(content));
-    }
-
-    // Run the test.
-    {
-        let last_header = snapshot
-            .get_verifiable_header_by_number(num)
-            .expect("block stored");
-        let headers = block_numbers
-            .iter()
-            .map(|n| *n as BlockNumber)
-            .map(|n| snapshot.get_header_by_number(n).expect("block stored"))
-            .collect::<Vec<_>>();
-        let block_hashes = headers.iter().map(|h| h.hash()).collect::<Vec<_>>().pack();
-        let data = {
-            let headers = headers.iter().map(|h| h.data()).collect::<Vec<_>>();
-            let last_number: BlockNumber = last_header.header().raw().number().unpack();
-            let proof = chain.build_proof_by_numbers(last_number, &block_numbers);
-            let content = packed::SendBlocksProof::new_builder()
-                .last_header(last_header)
-                .proof(proof)
-                .headers(headers.pack())
-                .build();
-            packed::LightClientMessage::new_builder()
-                .set(content)
-                .build()
-        }
-        .as_bytes();
-
-        assert!(nc.sent_messages().borrow().is_empty());
-
-        protocol.received(nc.context(), peer_index, data).await;
-
-        assert!(nc.not_banned(peer_index));
-        assert_eq!(nc.sent_messages().borrow().len(), 1);
-
-        let data = &nc.sent_messages().borrow()[0].2;
-        let message = packed::SyncMessageReader::new_unchecked(&data);
-        let content = if let packed::SyncMessageUnionReader::GetBlocks(content) = message.to_enum()
-        {
-            content
-        } else {
-            panic!("unexpected message");
-        };
-        assert_eq!(content.block_hashes().as_slice(), block_hashes.as_slice());
-
-        let peer_state = protocol
-            .get_peer_state(&peer_index)
-            .expect("has peer state");
-        assert!(peer_state.get_blocks_proof_request().is_none());
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn valid_empty_proof() {
-    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
-    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
-
-    let peer_index = PeerIndex::new(1);
-    let peers = {
-        let peers = Arc::new(Peers::default());
-        peers.add_peer(peer_index);
-        peers
-    };
-    let mut protocol = chain.create_light_client_protocol(peers);
-
-    let num = 20;
-    chain.mine_to(20);
-
-    let snapshot = chain.shared().snapshot();
-
-    let block_numbers = (0..num).into_iter().collect::<Vec<_>>();
-
-    // Setup the test fixture.
-    {
-        let peer_state = protocol
-            .get_peer_state(&peer_index)
-            .expect("has peer state");
-        let prove_request = {
-            let last_header: VerifiableHeader = snapshot
-                .get_verifiable_header_by_number(num)
-                .expect("block stored")
-                .into();
-            let content = protocol
-                .build_prove_request_content(&peer_state, &last_header)
-                .expect("build prove request content");
-            let last_state = LastState::new(last_header);
-            protocol
-                .peers()
-                .update_last_state(peer_index, last_state.clone());
-            ProveRequest::new(last_state, content)
-        };
-        let last_state = LastState::new(prove_request.get_last_header().to_owned());
-        let prove_state = {
-            let last_n_blocks_start_number = if num > protocol.last_n_blocks() + 1 {
-                num - protocol.last_n_blocks()
-            } else {
-                1
-            };
-            let last_n_headers = (last_n_blocks_start_number..num)
-                .into_iter()
-                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
-                .collect::<Vec<_>>();
-            ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
-        };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
-        protocol.peers().update_last_state(peer_index, last_state);
-        protocol
-            .peers()
-            .update_prove_request(peer_index, Some(prove_request));
-        protocol.commit_prove_state(peer_index, prove_state);
-        protocol
-            .peers()
-            .update_blocks_proof_request(peer_index, Some(content));
-    }
-
-    // Run the test.
-    {
-        let last_header = snapshot
-            .get_verifiable_header_by_number(num)
-            .expect("block stored");
-        let headers = block_numbers
-            .iter()
-            .map(|n| *n as BlockNumber)
-            .map(|n| snapshot.get_header_by_number(n).expect("block stored"))
-            .collect::<Vec<_>>();
-        let block_hashes = headers.iter().map(|h| h.hash()).collect::<Vec<_>>().pack();
-        let data = {
-            let headers = headers.iter().map(|h| h.data()).collect::<Vec<_>>();
-            let last_number: BlockNumber = last_header.header().raw().number().unpack();
-            let proof = chain.build_proof_by_numbers(last_number, &block_numbers);
-            assert!(proof.is_empty());
-            let content = packed::SendBlocksProof::new_builder()
-                .last_header(last_header)
-                .proof(proof)
-                .headers(headers.pack())
-                .build();
-            packed::LightClientMessage::new_builder()
-                .set(content)
-                .build()
-        }
-        .as_bytes();
-
-        assert!(nc.sent_messages().borrow().is_empty());
-
-        protocol.received(nc.context(), peer_index, data).await;
-
-        assert!(nc.not_banned(peer_index));
-        assert_eq!(nc.sent_messages().borrow().len(), 1);
-
-        let data = &nc.sent_messages().borrow()[0].2;
-        let message = packed::SyncMessageReader::new_unchecked(&data);
-        let content = if let packed::SyncMessageUnionReader::GetBlocks(content) = message.to_enum()
-        {
-            content
-        } else {
-            panic!("unexpected message");
-        };
-        assert_eq!(content.block_hashes().as_slice(), block_hashes.as_slice());
-
-        let peer_state = protocol
-            .get_peer_state(&peer_index)
-            .expect("has peer state");
-        assert!(peer_state.get_blocks_proof_request().is_none());
     }
 }
 
@@ -535,7 +308,7 @@ async fn get_blocks_with_chunks() {
                 .collect::<Vec<_>>();
             ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
         };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
+        let content = chain.build_blocks_proof_content(num, &block_numbers, &[]);
         protocol.peers().update_last_state(peer_index, last_state);
         protocol
             .peers()
@@ -618,7 +391,186 @@ async fn get_blocks_with_chunks() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn invalid_proof() {
+async fn valid_proof() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_without_any_proof_items() {
+    let last_block_number = 20;
+    let block_numbers = (0..last_block_number).into_iter().collect::<Vec<_>>();
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_proof_with_missing_block_hashes() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let missing_block_hashes = vec![h256!("0x1").pack(), h256!("0x2").pack()];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        missing_block_hashes: missing_block_hashes.clone(),
+        returned_missing_block_hashes: missing_block_hashes,
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_insufficient_missing_block_hashes() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let missing_block_hashes = vec![h256!("0x1").pack(), h256!("0x2").pack()];
+    let returned_missing_block_hashes = vec![h256!("0x1").pack()];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        missing_block_hashes,
+        returned_missing_block_hashes,
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_redundant_missing_block_hashes() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let missing_block_hashes = vec![h256!("0x1").pack()];
+    let returned_missing_block_hashes = vec![h256!("0x1").pack(), h256!("0x2").pack()];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        missing_block_hashes,
+        returned_missing_block_hashes,
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_duplicate_missing_block_hashes() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let missing_block_hashes = vec![h256!("0x1").pack()];
+    let returned_missing_block_hashes = vec![h256!("0x1").pack(), h256!("0x1").pack()];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        missing_block_hashes,
+        returned_missing_block_hashes,
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_insufficient_proved_blocks() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let proved_block_numbers = vec![3, 5, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: proved_block_numbers,
+        returned_headers: block_numbers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_redundant_proved_blocks() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let proved_block_numbers = vec![3, 5, 7, 8, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: proved_block_numbers,
+        returned_headers: block_numbers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_insufficient_returned_headers() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let returned_headers = vec![3, 5, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers,
+        returned_headers: returned_headers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_redundant_returned_headers() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let returned_headers = vec![3, 5, 7, 8, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers,
+        returned_headers: returned_headers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_proof_with_duplicate_returned_headers() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let returned_headers = vec![3, 5, 8, 11, 16, 18, 8];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers,
+        returned_headers: returned_headers,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[derive(Default)]
+struct TestParameter {
+    last_block_number: BlockNumber,
+    block_numbers: Vec<BlockNumber>,
+    proved_block_numbers: Vec<BlockNumber>,
+    returned_headers: Vec<BlockNumber>,
+    missing_block_hashes: Vec<packed::Byte32>,
+    returned_missing_block_hashes: Vec<packed::Byte32>,
+}
+
+async fn test_send_blocks_proof(param: TestParameter) {
     let chain = MockChain::new_with_dummy_pow("test-light-client").start();
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);
 
@@ -630,13 +582,10 @@ async fn invalid_proof() {
     };
     let mut protocol = chain.create_light_client_protocol(peers);
 
-    let num = 20;
-    chain.mine_to(20);
+    let num = param.last_block_number;
+    chain.mine_to(num);
 
     let snapshot = chain.shared().snapshot();
-
-    let block_numbers = vec![3, 5, 8, 11, 16, 18];
-    let proved_block_numbers = vec![3, 5, 7, 11, 16, 18];
 
     // Setup the test fixture.
     {
@@ -670,7 +619,11 @@ async fn invalid_proof() {
                 .collect::<Vec<_>>();
             ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
         };
-        let content = chain.build_blocks_proof_content(num, &block_numbers);
+        let content = chain.build_blocks_proof_content(
+            num,
+            &param.block_numbers,
+            &param.missing_block_hashes,
+        );
         protocol.peers().update_last_state(peer_index, last_state);
         protocol
             .peers()
@@ -686,23 +639,26 @@ async fn invalid_proof() {
         let last_header = snapshot
             .get_verifiable_header_by_number(num)
             .expect("block stored");
+        let headers = param
+            .returned_headers
+            .iter()
+            .map(|n| *n as BlockNumber)
+            .map(|n| snapshot.get_header_by_number(n).expect("block stored"))
+            .collect::<Vec<_>>();
+        let block_hashes = headers.iter().map(|h| h.hash()).collect::<Vec<_>>().pack();
         let data = {
-            let headers = block_numbers
-                .iter()
-                .map(|n| *n as BlockNumber)
-                .map(|n| {
-                    snapshot
-                        .get_header_by_number(n)
-                        .expect("block stored")
-                        .data()
-                })
-                .collect::<Vec<_>>();
+            let headers = headers.iter().map(|h| h.data()).collect::<Vec<_>>();
             let last_number: BlockNumber = last_header.header().raw().number().unpack();
-            let proof = chain.build_proof_by_numbers(last_number, &proved_block_numbers);
+            let proof = chain.build_proof_by_numbers(last_number, &param.proved_block_numbers);
+            let all_block_numbers = (0..last_number).into_iter().collect::<Vec<_>>();
+            if param.proved_block_numbers == all_block_numbers {
+                assert!(proof.is_empty());
+            }
             let content = packed::SendBlocksProof::new_builder()
                 .last_header(last_header)
                 .proof(proof)
                 .headers(headers.pack())
+                .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
                 .build();
             packed::LightClientMessage::new_builder()
                 .set(content)
@@ -714,7 +670,39 @@ async fn invalid_proof() {
 
         protocol.received(nc.context(), peer_index, data).await;
 
-        assert!(nc.banned_since(peer_index, StatusCode::InvalidProof));
-        assert!(nc.sent_messages().borrow().is_empty());
+        if param.block_numbers == param.proved_block_numbers
+            && param.block_numbers == param.returned_headers
+            && param.missing_block_hashes == param.returned_missing_block_hashes
+        {
+            assert!(nc.not_banned(peer_index));
+            assert_eq!(nc.sent_messages().borrow().len(), 1);
+
+            let data = &nc.sent_messages().borrow()[0].2;
+            let message = packed::SyncMessageReader::new_unchecked(&data);
+            let content =
+                if let packed::SyncMessageUnionReader::GetBlocks(content) = message.to_enum() {
+                    content
+                } else {
+                    panic!("unexpected message");
+                };
+            assert_eq!(content.block_hashes().as_slice(), block_hashes.as_slice());
+
+            let peer_state = protocol
+                .get_peer_state(&peer_index)
+                .expect("has peer state");
+            assert!(peer_state.get_blocks_proof_request().is_none());
+        } else {
+            if param.missing_block_hashes != param.returned_missing_block_hashes
+                || param.block_numbers != param.returned_headers
+            {
+                assert!(nc.banned_since(peer_index, StatusCode::UnexpectedResponse));
+            } else if param.block_numbers != param.proved_block_numbers {
+                assert!(nc.banned_since(peer_index, StatusCode::InvalidProof));
+            } else {
+                panic!("unhandled failed tests");
+            }
+
+            assert!(nc.sent_messages().borrow().is_empty());
+        }
     }
 }

--- a/src/tests/protocols/light_client/send_blocks_proof.rs
+++ b/src/tests/protocols/light_client/send_blocks_proof.rs
@@ -368,6 +368,120 @@ async fn valid_proof() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn valid_empty_proof() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = Arc::new(Peers::default());
+        peers.add_peer(peer_index);
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let num = 20;
+    chain.mine_to(20);
+
+    let snapshot = chain.shared().snapshot();
+
+    let block_numbers = (0..num).into_iter().collect::<Vec<_>>();
+
+    // Setup the test fixture.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone());
+            ProveRequest::new(last_state, content)
+        };
+        let last_state = LastState::new(prove_request.get_last_header().to_owned());
+        let prove_state = {
+            let last_n_blocks_start_number = if num > protocol.last_n_blocks() + 1 {
+                num - protocol.last_n_blocks()
+            } else {
+                1
+            };
+            let last_n_headers = (last_n_blocks_start_number..num)
+                .into_iter()
+                .map(|num| snapshot.get_header_by_number(num).expect("block stored"))
+                .collect::<Vec<_>>();
+            ProveState::new_from_request(prove_request.clone(), Vec::new(), last_n_headers)
+        };
+        let content = chain.build_blocks_proof_content(num, &block_numbers);
+        protocol.peers().update_last_state(peer_index, last_state);
+        protocol
+            .peers()
+            .update_prove_request(peer_index, Some(prove_request));
+        protocol.commit_prove_state(peer_index, prove_state);
+        protocol
+            .peers()
+            .update_blocks_proof_request(peer_index, Some(content));
+    }
+
+    // Run the test.
+    {
+        let last_header = snapshot
+            .get_verifiable_header_by_number(num)
+            .expect("block stored");
+        let headers = block_numbers
+            .iter()
+            .map(|n| *n as BlockNumber)
+            .map(|n| snapshot.get_header_by_number(n).expect("block stored"))
+            .collect::<Vec<_>>();
+        let block_hashes = headers.iter().map(|h| h.hash()).collect::<Vec<_>>().pack();
+        let data = {
+            let headers = headers.iter().map(|h| h.data()).collect::<Vec<_>>();
+            let last_number: BlockNumber = last_header.header().raw().number().unpack();
+            let proof = chain.build_proof_by_numbers(last_number, &block_numbers);
+            assert!(proof.is_empty());
+            let content = packed::SendBlocksProof::new_builder()
+                .last_header(last_header)
+                .proof(proof)
+                .headers(headers.pack())
+                .build();
+            packed::LightClientMessage::new_builder()
+                .set(content)
+                .build()
+        }
+        .as_bytes();
+
+        assert!(nc.sent_messages().borrow().is_empty());
+
+        protocol.received(nc.context(), peer_index, data).await;
+
+        assert!(nc.not_banned(peer_index));
+        assert_eq!(nc.sent_messages().borrow().len(), 1);
+
+        let data = &nc.sent_messages().borrow()[0].2;
+        let message = packed::SyncMessageReader::new_unchecked(&data);
+        let content = if let packed::SyncMessageUnionReader::GetBlocks(content) = message.to_enum()
+        {
+            content
+        } else {
+            panic!("unexpected message");
+        };
+        assert_eq!(content.block_hashes().as_slice(), block_hashes.as_slice());
+
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        assert!(peer_state.get_blocks_proof_request().is_none());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_blocks_with_chunks() {
     let chain = MockChain::new_with_dummy_pow("test-light-client").start();
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);

--- a/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -157,7 +157,7 @@ async fn test_send_txs_proof_ok() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert!(nc.sent_messages().borrow().is_empty());
     assert_eq!(
         peers
@@ -499,7 +499,7 @@ async fn test_send_txs_proof_is_empty() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert!(nc.sent_messages().borrow().is_empty());
 }
 
@@ -549,7 +549,7 @@ async fn test_send_headers_txs_request() {
     let mut protocol = chain.create_light_client_protocol(Arc::clone(&peers));
     protocol.notify(nc.context(), FETCH_HEADER_TX_TOKEN).await;
 
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     assert_eq!(nc.sent_messages().borrow().len(), 2);
 
     assert!(peers.fetching_headers().get(&h256!("0xaa33")).unwrap().1 > 0);

--- a/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -499,7 +499,7 @@ async fn test_send_txs_proof_is_empty() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.not_banned(peer_index));
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidProof));
     assert!(nc.sent_messages().borrow().is_empty());
 }
 

--- a/src/tests/protocols/synchronizer.rs
+++ b/src/tests/protocols/synchronizer.rs
@@ -70,7 +70,7 @@ async fn test_sync_add_block() {
         .client_storage()
         .get_earliest_matched_blocks()
         .is_none());
-    assert!(nc.banned_peers().borrow().is_empty());
+    assert!(nc.not_banned(peer_index));
     let storage_filtered_block_number = chain
         .client_storage()
         .get_filter_scripts()

--- a/src/tests/utils/network_context.rs
+++ b/src/tests/utils/network_context.rs
@@ -49,7 +49,7 @@ impl MockNetworkContext {
         &self.inner.sent_messages
     }
 
-    pub(crate) fn banned_peers(&self) -> &RefCell<Vec<(PeerIndex, Duration, String)>> {
+    fn banned_peers(&self) -> &RefCell<Vec<(PeerIndex, Duration, String)>> {
         &self.inner.banned_peers
     }
 


### PR DESCRIPTION
### Issues

- The old request should always be removed when a response was processed.

  But when errors are thrown through the `?` operation, the old request is **NOT** removed.

- A normal proof could be empty.

  Currently, the client consider the last state requires an update when proof is empty.

  But the proof is empty doesn't mean there is no proof; maybe the data which you want to prove is enough to prove themselves.

  For example, if the last block number is `10`, and you want a proof for block `[0,1,2,3,4,5,6,7,8,9]`,then the proof items is empty.

- Handle missing items for a proof.

_p.s. I put them together in one PR, since they all are related to the comparison between the request and the response._
