### PR TITLE
refactor: support type script filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Set some scripts to filter
 #### Parameters
 
     script - Script
+    script_type - Enum "lock" or "type"
     block_number - Filter start number
 
 #### Returns
@@ -77,7 +78,7 @@ Set some scripts to filter
 #### Examples
 
 ```
-curl http://localhost:9000/ -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method":"set_scripts", "params": [[{"script": {"code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8", "hash_type": "type", "args": "0x50878ce52a68feb47237c29574d82288f58b5d21"}, "block_number": "0x0"}]], "id": 1}'
+curl http://localhost:9000/ -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method":"set_scripts", "params": [[{"script": {"code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8", "hash_type": "type", "args": "0x50878ce52a68feb47237c29574d82288f58b5d21"}, "script_type": "lock", "block_number": "0x0"}]], "id": 1}'
 ```
 
 ### `get_scripts`
@@ -91,6 +92,7 @@ Get filter scripts status
 #### Returns
 
     script - Script
+    script_type - Enum "lock" or "type"
     block_number - Filtered block number
 
 #### Examples

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 use ckb_traits::{CellDataProvider, HeaderProvider};
 use ckb_types::{
@@ -23,6 +23,18 @@ const GENESIS_BLOCK_KEY: &str = "GENESIS_BLOCK";
 const FILTER_SCRIPTS_KEY: &str = "FILTER_SCRIPTS";
 const MATCHED_FILTER_BLOCKS_KEY: &str = "MATCHED_BLOCKS";
 const MIN_FILTERED_BLOCK_NUMBER: &str = "MIN_FILTERED_NUMBER";
+
+pub struct ScriptStatus {
+    pub script: Script,
+    pub script_type: ScriptType,
+    pub block_number: BlockNumber,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum ScriptType {
+    Lock,
+    Type,
+}
 
 #[derive(Clone)]
 pub struct Storage {
@@ -142,7 +154,7 @@ impl Storage {
             .build()
     }
 
-    pub fn get_filter_scripts(&self) -> HashMap<Script, BlockNumber> {
+    pub fn get_filter_scripts(&self) -> Vec<ScriptStatus> {
         let key_prefix = Key::Meta(FILTER_SCRIPTS_KEY).into_vec();
         let mode = IteratorMode::From(key_prefix.as_ref(), Direction::Forward);
 
@@ -150,19 +162,28 @@ impl Storage {
             .iterator(mode)
             .take_while(|(key, _value)| key.starts_with(&key_prefix))
             .map(|(key, value)| {
-                let script = Script::from_slice(&key[key_prefix.len()..]).expect("stored Script");
+                let script = Script::from_slice(&key[key_prefix.len()..key.len() - 1])
+                    .expect("stored Script");
+                let script_type = match key[key.len() - 1] {
+                    0 => ScriptType::Lock,
+                    1 => ScriptType::Type,
+                    _ => panic!("invalid script type"),
+                };
                 let block_number = BlockNumber::from_be_bytes(
                     value.as_ref().try_into().expect("stored BlockNumber"),
                 );
-                (script, block_number)
+                ScriptStatus {
+                    script,
+                    script_type,
+                    block_number,
+                }
             })
             .collect()
     }
 
     /// Update all filter scripts' status to the specified block number and delete the outdated ones.
-    pub fn update_filter_scripts(&self, scripts: HashMap<Script, BlockNumber>) {
-        let should_filter_genesis_block =
-            scripts.iter().any(|(_, block_number)| *block_number == 0);
+    pub fn update_filter_scripts(&self, scripts: Vec<ScriptStatus>) {
+        let should_filter_genesis_block = scripts.iter().any(|ss| ss.block_number == 0);
         let mut batch = self.batch();
 
         let key_prefix = Key::Meta(FILTER_SCRIPTS_KEY).into_vec();
@@ -175,10 +196,18 @@ impl Storage {
                 batch.delete(key).expect("batch delete should be ok");
             });
 
-        for (script, block_number) in scripts {
-            let key = [key_prefix.as_ref(), script.as_slice()].concat();
+        for ss in scripts {
+            let key = [
+                key_prefix.as_ref(),
+                ss.script.as_slice(),
+                match ss.script_type {
+                    ScriptType::Lock => &[0],
+                    ScriptType::Type => &[1],
+                },
+            ]
+            .concat();
             batch
-                .put(key, block_number.to_be_bytes())
+                .put(key, ss.block_number.to_be_bytes())
                 .expect("batch put should be ok");
         }
         batch.commit().expect("batch commit should be ok");
@@ -202,8 +231,8 @@ impl Storage {
                     value.as_ref().try_into().expect("stored BlockNumber"),
                 );
                 if stored_block_number < block_number {
-                    let script =
-                        Script::from_slice(&key[key_prefix.len()..]).expect("stored Script");
+                    let script = Script::from_slice(&key[key_prefix.len()..key.len() - 1])
+                        .expect("stored Script");
                     Some(script.calc_script_hash())
                 } else {
                     None
@@ -376,7 +405,11 @@ impl Storage {
     }
 
     pub fn filter_block(&self, block: Block) {
-        let scripts = self.get_filter_scripts();
+        let scripts: HashSet<(Script, ScriptType)> = self
+            .get_filter_scripts()
+            .into_iter()
+            .map(|ss| (ss.script, ss.script_type))
+            .collect();
         let block_number: BlockNumber = block.header().raw().number().unpack();
         let mut filter_matched = false;
         let mut batch = self.batch();
@@ -401,7 +434,7 @@ impl Storage {
                                 previous_tx.raw().outputs().get(previous_output_index)
                             {
                                 let script = previous_output.lock();
-                                if scripts.contains_key(&script) {
+                                if scripts.contains(&(script.clone(), ScriptType::Lock)) {
                                     filter_matched = true;
                                     // delete utxo
                                     let key = Key::CellLockScript(
@@ -441,7 +474,7 @@ impl Storage {
                     .enumerate()
                     .for_each(|(output_index, output)| {
                         let script = output.lock();
-                        if scripts.contains_key(&script) {
+                        if scripts.contains(&(script.clone(), ScriptType::Lock)) {
                             filter_matched = true;
                             let tx_hash = tx.calc_tx_hash();
                             // insert utxo
@@ -497,9 +530,13 @@ impl Storage {
         let scripts = self.get_filter_scripts();
         let mut batch = self.batch();
 
-        for (script, filtered_block_number) in scripts {
-            if filtered_block_number >= to_number {
-                let mut key_prefix = vec![KeyPrefix::TxLockScript as u8];
+        for ss in scripts {
+            if ss.block_number >= to_number {
+                let script = ss.script;
+                let mut key_prefix = vec![match ss.script_type {
+                    ScriptType::Lock => KeyPrefix::TxLockScript as u8,
+                    ScriptType::Type => KeyPrefix::TxTypeScript as u8,
+                }];
                 key_prefix.extend_from_slice(&extract_raw_data(&script));
                 let mut start_key = key_prefix.clone();
                 start_key.extend_from_slice(BlockNumber::MAX.to_be_bytes().as_ref());
@@ -589,6 +626,10 @@ impl Storage {
                 {
                     let mut key = Key::Meta(FILTER_SCRIPTS_KEY).into_vec();
                     key.extend_from_slice(script.as_slice());
+                    key.extend_from_slice(match ss.script_type {
+                        ScriptType::Lock => &[0],
+                        ScriptType::Type => &[1],
+                    });
                     let value = to_number.to_be_bytes().to_vec();
                     batch.put(key, value).expect("batch put should be ok");
                 }

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -13,6 +13,7 @@ use ckb_types::{
     H256, U256,
 };
 
+use crate::storage::{ScriptStatus, ScriptType};
 use crate::{
     protocols::{
         LastState, Peers, ProveRequest, ProveState, BAD_MESSAGE_BAN_TIME, GET_BLOCK_FILTERS_TOKEN,
@@ -47,11 +48,13 @@ async fn test_block_filter_ignore_start_number() {
     let nc = MockNetworkContext::new(SupportProtocols::Filter);
 
     let min_filtered_block_number = 3;
-    chain.client_storage().update_filter_scripts(
-        vec![(Script::default(), min_filtered_block_number)]
-            .into_iter()
-            .collect(),
-    );
+    chain
+        .client_storage()
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: min_filtered_block_number,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -98,11 +101,13 @@ async fn test_block_filter_empty_filters() {
     let nc = MockNetworkContext::new(SupportProtocols::Filter);
 
     let min_filtered_block_number = 3;
-    chain.client_storage().update_filter_scripts(
-        vec![(Script::default(), min_filtered_block_number)]
-            .into_iter()
-            .collect(),
-    );
+    chain
+        .client_storage()
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: min_filtered_block_number,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -154,7 +159,11 @@ async fn test_block_filter_invalid_filters_count() {
         .update_min_filtered_block_number(min_filtered_block_number);
     chain
         .client_storage()
-        .update_filter_scripts(vec![(Script::default(), 0)].into_iter().collect());
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: 0,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -206,11 +215,13 @@ async fn test_block_filter_start_number_greater_then_proved_number() {
     let min_filtered_block_number = 3;
     let proved_number = min_filtered_block_number;
     let start_number = min_filtered_block_number + 1;
-    chain.client_storage().update_filter_scripts(
-        vec![(Script::default(), min_filtered_block_number)]
-            .into_iter()
-            .collect(),
-    );
+    chain
+        .client_storage()
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: min_filtered_block_number,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -435,7 +446,11 @@ async fn test_block_filter_notify_ask_filters() {
     // for should_ask() return true
     chain
         .client_storage()
-        .update_filter_scripts(vec![(Script::default(), 0)].into_iter().collect());
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: 0,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -504,11 +519,13 @@ async fn test_block_filter_notify_not_reach_ask() {
     let nc = MockNetworkContext::new(SupportProtocols::Filter);
 
     let min_filtered_block_number = 3;
-    chain.client_storage().update_filter_scripts(
-        vec![(Script::default(), min_filtered_block_number)]
-            .into_iter()
-            .collect(),
-    );
+    chain
+        .client_storage()
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: min_filtered_block_number,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {
@@ -550,7 +567,11 @@ async fn test_block_filter_notify_proved_number_not_big_enough() {
     // for should_ask() return true
     chain
         .client_storage()
-        .update_filter_scripts(vec![(Script::default(), 0)].into_iter().collect());
+        .update_filter_scripts(vec![ScriptStatus {
+            script: Script::default(),
+            script_type: ScriptType::Lock,
+            block_number: 0,
+        }]);
 
     let peer_index = PeerIndex::new(3);
     let peers = {

--- a/src/tests/service.rs
+++ b/src/tests/service.rs
@@ -119,6 +119,11 @@ fn rpc() {
             block_number: 0,
         },
         storage::ScriptStatus {
+            script: type_script1.clone(),
+            script_type: storage::ScriptType::Type,
+            block_number: 0,
+        },
+        storage::ScriptStatus {
             script: lock_script3,
             script_type: storage::ScriptType::Lock,
             block_number: 0,
@@ -127,19 +132,26 @@ fn rpc() {
 
     // test get_scripts rpc
     let scripts = rpc.get_scripts().unwrap();
-    assert_eq!(scripts.len(), 2);
+    assert_eq!(scripts.len(), 3);
 
     // test set_scripts rpc
-    rpc.set_scripts(vec![ScriptStatus {
-        script: lock_script1.clone().into(),
-        script_type: ScriptType::Lock,
-        block_number: 0.into(),
-    }])
+    rpc.set_scripts(vec![
+        ScriptStatus {
+            script: lock_script1.clone().into(),
+            script_type: ScriptType::Lock,
+            block_number: 0.into(),
+        },
+        ScriptStatus {
+            script: type_script1.clone().into(),
+            script_type: ScriptType::Type,
+            block_number: 0.into(),
+        },
+    ])
     .unwrap();
     let scripts = rpc.get_scripts().unwrap();
     assert_eq!(
         scripts.len(),
-        1,
+        2,
         "set_scripts should override the old scripts and delete the lock_script3"
     );
 
@@ -226,6 +238,25 @@ fn rpc() {
         total_blocks as usize + 1,
         cells_page_1.objects.len() + cells_page_2.objects.len(),
         "total size should be cellbase cells count + 1 (last block live cell)"
+    );
+
+    let cells_page_1 = rpc
+        .get_cells(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                ..Default::default()
+            },
+            Order::Asc,
+            150.into(),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        1,
+        cells_page_1.objects.len(),
+        "total size should be 1 (last block live cell)"
     );
 
     let cells_page_1 = rpc
@@ -343,6 +374,37 @@ fn rpc() {
         .unwrap();
 
     assert_eq!(total_blocks as usize * 3 - 1, txs_page_1.objects.len() + txs_page_2.objects.len(), "total size should be cellbase tx count + total_block * 2 - 1 (genesis block only has one tx)");
+
+    let txs_page_1 = rpc
+        .get_transactions(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                ..Default::default()
+            },
+            Order::Asc,
+            500.into(),
+            None,
+        )
+        .unwrap();
+    let txs_page_2 = rpc
+        .get_transactions(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                ..Default::default()
+            },
+            Order::Asc,
+            500.into(),
+            Some(txs_page_1.last_cursor),
+        )
+        .unwrap();
+
+    assert_eq!(
+        total_blocks as usize * 2 - 1,
+        txs_page_1.objects.len() + txs_page_2.objects.len(),
+        "total size should be total_block * 2 - 1 (genesis block only has one tx)"
+    );
 
     let desc_txs_page_1 = rpc
         .get_transactions(
@@ -478,6 +540,39 @@ fn rpc() {
         txs_page_2.objects.last().unwrap().tx_hash(),
     );
 
+    let txs_page_1 = rpc
+        .get_transactions(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                group_by_transaction: Some(true),
+                ..Default::default()
+            },
+            Order::Asc,
+            300.into(),
+            None,
+        )
+        .unwrap();
+    let txs_page_2 = rpc
+        .get_transactions(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                group_by_transaction: Some(true),
+                ..Default::default()
+            },
+            Order::Asc,
+            300.into(),
+            Some(txs_page_1.last_cursor),
+        )
+        .unwrap();
+
+    assert_eq!(
+        total_blocks as usize,
+        txs_page_1.objects.len() + txs_page_2.objects.len(),
+        "total size should be total_block"
+    );
+
     let filter_txs_page_1 = rpc
         .get_transactions(
             SearchKey {
@@ -531,6 +626,16 @@ fn rpc() {
         capacity.value(),
         "cellbases + last block live cell"
     );
+
+    let capacity = rpc
+        .get_cells_capacity(SearchKey {
+            script: type_script1.clone().into(),
+            script_type: ScriptType::Type,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(1000 * 100000000, capacity.value(), "last block live cell");
 
     let capacity = rpc
         .get_cells_capacity(SearchKey {
@@ -656,11 +761,18 @@ fn rpc() {
 
     // test rollback_filtered_transactions
     // rollback 2 blocks
-    storage.update_filter_scripts(vec![storage::ScriptStatus {
-        script: lock_script1.clone(),
-        script_type: storage::ScriptType::Lock,
-        block_number: total_blocks,
-    }]);
+    storage.update_filter_scripts(vec![
+        storage::ScriptStatus {
+            script: lock_script1.clone(),
+            script_type: storage::ScriptType::Lock,
+            block_number: total_blocks,
+        },
+        storage::ScriptStatus {
+            script: type_script1.clone(),
+            script_type: storage::ScriptType::Type,
+            block_number: total_blocks,
+        },
+    ]);
     storage.rollback_to_block((total_blocks - 2).into());
 
     let scripts = storage.get_filter_scripts();
@@ -703,6 +815,25 @@ fn rpc() {
             cells_page_1.objects.len() + cells_page_2.objects.len(),
             "total size should be cellbase cells count + 1 (last block live cell) - 2 (rollbacked blocks cells)"
         );
+
+    let cells_page_1 = rpc
+        .get_cells(
+            SearchKey {
+                script: type_script1.clone().into(),
+                script_type: ScriptType::Type,
+                ..Default::default()
+            },
+            Order::Asc,
+            150.into(),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        1,
+        cells_page_1.objects.len(),
+        "total size should be 1 (last block live cell)"
+    );
 
     // test get_transactions rpc after rollback
     let txs_page_1 = rpc

--- a/src/tests/verify.rs
+++ b/src/tests/verify.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use ckb_jsonrpc_types::{Block, Script, Transaction};
 use ckb_types::packed;
 
 use crate::{
-    storage::StorageWithChainData,
+    storage::{ScriptStatus, ScriptType, StorageWithChainData},
     tests::{prelude::*, utils::MockChain},
     verify::verify_tx,
 };
@@ -17,8 +15,11 @@ fn verify_valid_transaction() {
 
     // https://pudge.explorer.nervos.org/address/ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq0l2z2v9305wm7rs5gqrpsf507ey8wj3tggtl4sj
     let script: packed::Script = serde_json::from_str::<Script>(r#"{"code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8","hash_type": "type","args": "0xff5094c2c5f476fc38510018609a3fd921dd28ad"}"#).unwrap().into();
-    let mut scripts = HashMap::new();
-    scripts.insert(script, 0);
+    let scripts = vec![ScriptStatus {
+        script,
+        script_type: ScriptType::Lock,
+        block_number: 0,
+    }];
     storage.update_filter_scripts(scripts);
 
     // https://pudge.explorer.nervos.org/block/261


### PR DESCRIPTION
note: this is a breaking change, need to delate light client's `data` folder and re-set the scripts to filter.