### PR TITLE
fix: re-sent fetching request when not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ curl http://localhost:9000/ -X POST -H "Content-Type: application/json" -d '{"js
 
 ### `fetch_header`
 
-Fetch a header from remote node.
+Fetch a header from remote node. If return status is `not_found` will re-sent fetching request immediately.
 
 #### Parameters
 
@@ -209,7 +209,7 @@ Fetch a header from remote node.
 
 ### `fetch_transaction`
 
-Fetch a transaction from remote node.
+Fetch a transaction from remote node. If return status is `not_found` will re-sent fetching request immediately.
 
 #### Parameters
 

--- a/src/protocols/light_client/constant.rs
+++ b/src/protocols/light_client/constant.rs
@@ -5,6 +5,6 @@ pub const FETCH_HEADER_TX_TOKEN: u64 = 1;
 // notify token to send GetBlocksProof and GetBlocks for previously timeout requests
 pub const GET_IDLE_BLOCKS_TOKEN: u64 = 2;
 
-pub const REFRESH_PEERS_DURATION: Duration = Duration::from_secs(60);
+pub const REFRESH_PEERS_DURATION: Duration = Duration::from_secs(8);
 pub const FETCH_HEADER_TX_DURATION: Duration = Duration::from_secs(3);
 pub const GET_IDLE_BLOCKS_DURATION: Duration = Duration::from_secs(3);

--- a/src/service.rs
+++ b/src/service.rs
@@ -1037,6 +1037,11 @@ impl ChainRpc for ChainRpcImpl {
 
     fn fetch_header(&self, block_hash: H256) -> Result<FetchStatus<HeaderView>> {
         if let Some(value) = self.get_header(block_hash.clone())? {
+            if self.swc.storage().get_header(&block_hash.pack()).is_none() {
+                self.swc
+                    .storage()
+                    .add_fetched_header(&value.inner.clone().into());
+            }
             return Ok(FetchStatus::Fetched { data: value });
         }
         let now = unix_time_as_millis();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1042,6 +1042,8 @@ impl ChainRpc for ChainRpcImpl {
         let now = unix_time_as_millis();
         if let Some((added_ts, first_sent, missing)) = self.swc.get_header_fetch_info(&block_hash) {
             if missing {
+                // re-fetch the header
+                self.swc.add_fetch_header(block_hash, now);
                 return Ok(FetchStatus::NotFound);
             } else if first_sent > 0 {
                 return Ok(FetchStatus::Fetching {
@@ -1067,6 +1069,8 @@ impl ChainRpc for ChainRpcImpl {
         let now = unix_time_as_millis();
         if let Some((added_ts, first_sent, missing)) = self.swc.get_tx_fetch_info(&tx_hash) {
             if missing {
+                // re-fetch the transaction
+                self.swc.add_fetch_tx(tx_hash, now);
                 return Ok(FetchStatus::NotFound);
             } else if first_sent > 0 {
                 return Ok(FetchStatus::Fetching {

--- a/src/tests/service.rs
+++ b/src/tests/service.rs
@@ -787,6 +787,8 @@ fn rpc() {
     );
     let rv = rpc.fetch_header(h256!("0xaa404")).unwrap();
     assert_eq!(rv, FetchStatus::NotFound);
+    let rv = rpc.fetch_header(h256!("0xaa404")).unwrap();
+    assert!(matches!(rv, FetchStatus::Added { .. }));
 
     // test fetch_transaction rpc
     let rv = rpc.fetch_transaction(fetched_txs[0].clone()).unwrap();
@@ -820,6 +822,8 @@ fn rpc() {
     );
     let rv = rpc.fetch_transaction(h256!("0xbb404")).unwrap();
     assert_eq!(rv, FetchStatus::NotFound);
+    let rv = rpc.fetch_transaction(h256!("0xbb404")).unwrap();
+    assert!(matches!(rv, FetchStatus::Added { .. }));
 
     assert_eq!(peers.fetching_headers().len(), 4);
     assert_eq!(peers.fetching_txs().len(), 4);


### PR DESCRIPTION
### Changes
* re-sent fetching request when not found
* add exists fetching header to storage
* change refresh peers duration from 60s to 8s