### PR TITLE
fix: unmatched MMR activate epoch for dev chain

### DIFF
--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -388,7 +388,7 @@ impl LightClientProtocol {
         if self.consensus.is_public_chain() {
             EpochNumber::MAX
         } else {
-            1
+            0
         }
     }
 

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -73,7 +73,9 @@ pub(crate) trait ChainExt {
     fn create_light_client_protocol(&self, peers: Arc<Peers>) -> LightClientProtocol {
         let storage = self.client_storage().to_owned();
         let consensus = self.consensus().to_owned();
-        LightClientProtocol::new(storage, peers, consensus)
+        let mut protocol = LightClientProtocol::new(storage, peers, consensus);
+        protocol.set_mmr_activated_epoch(1);
+        protocol
     }
 
     fn create_filter_protocol(&self, peers: Arc<Peers>) -> FilterProtocol {


### PR DESCRIPTION
### Issues

The MMR activate epoch for dev chains is incorrect.

[Code for dev chain in CKB:](https://github.com/nervosnetwork/ckb/blob/5aa8b426d0aef48c5a854a74176b5eb9b85896fb/spec/src/lib.rs#L527-L535)

```rust
                let light_client = Deployment {
                    bit: 1,
                    start: 0,
                    timeout: 0,
                    min_activation_epoch: 0,
                    period: 10,
                    active_mode: ActiveMode::Always,
                    threshold: TESTNET_ACTIVATION_THRESHOLD,
                };
```

Also, add a method to change the MMR activate epoch for unit tests, since MMR activate epochs are non-zero in both of the mainnet and the testnet, and we have to test for that.