### PR TITLE
fix: detect long fork

### DIFF
--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -342,6 +342,9 @@ impl LightClientProtocol {
                             debug!("rollback to block#{}", rollback_to);
                             self.storage.rollback_to_block(rollback_to);
                             matched_blocks.clear();
+                        } else {
+                            error!("Long fork detected, please check if ckb-light-client is connected to the same network ckb node. If you connected ckb-light-client to a dev chain for testing purpose you should remove the storage of ckb-light-client to recover.");
+                            panic!("long fork detected");
                         }
                     }
                 }

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -359,7 +359,7 @@ async fn test_block_filter_ok_with_blocks_matched() {
         VerifiableHeader::new(header.clone(), Default::default(), None, Default::default());
     chain
         .client_storage()
-        .update_last_state(&U256::one(), &tip_header.header().data());
+        .update_last_state(&U256::one(), &tip_header.header().data(), &[]);
 
     let peer_index = PeerIndex::new(3);
     let (peers, prove_state_block_hash) = {
@@ -622,7 +622,7 @@ async fn test_block_filter_notify_recover_matched_blocks() {
     let tip_hash = tip_header.header().hash();
     chain
         .client_storage()
-        .update_last_state(&U256::one(), &tip_header.header().data());
+        .update_last_state(&U256::one(), &tip_header.header().data(), &[]);
     let peers = {
         let last_state = LastState::new(tip_header);
         let request = ProveRequest::new(last_state, Default::default());

--- a/src/tests/protocols/light_client/mod.rs
+++ b/src/tests/protocols/light_client/mod.rs
@@ -67,7 +67,7 @@ fn build_prove_request_content() {
             .epoch(epoch.pack())
             .build();
         let last_total_difficulty = U256::from(last_total_difficulty);
-        storage.update_last_state(&last_total_difficulty, &header.data());
+        storage.update_last_state(&last_total_difficulty, &header.data(), &[]);
     }
 
     // Test different total difficulties.
@@ -177,7 +177,7 @@ async fn test_light_client_get_idle_matched_blocks() {
     );
     chain
         .client_storage()
-        .update_last_state(&U256::one(), &tip_header.header().data());
+        .update_last_state(&U256::one(), &tip_header.header().data(), &[]);
     let tip_hash = tip_header.header().hash();
     let peers = {
         let last_state = LastState::new(tip_header);

--- a/src/tests/service.rs
+++ b/src/tests/service.rs
@@ -1092,7 +1092,7 @@ fn get_cells_capacity_bug() {
         )
         .build();
     storage.filter_block(block2.data());
-    storage.update_last_state(&U256::one(), &block2.header().data());
+    storage.update_last_state(&U256::one(), &block2.header().data(), &[]);
 
     let cc = rpc
         .get_cells_capacity(SearchKey {


### PR DESCRIPTION
### Changes
* Detect long fork when reorg happen then panic
* Save last n headers (number+hash pair) into storage every time last state updated