### PR TITLE
ci: release executable binaries for new tags automatically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+name: Release
+on:
+  push:
+    tags: [ '*' ]
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+  RUST_TOOLCHAIN: 1.66.0
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, macos-11, windows-2019 ]
+        include:
+          - os: ubuntu-22.04
+            bin_suffix:
+            pkg_suffix: x86_64-linux
+          - os: macos-11
+            bin_suffix:
+            pkg_suffix: x86_64-darwin
+          - os: windows-2019
+            bin_suffix: .exe
+            pkg_suffix: x86_64-windows
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        override: true
+    - if: matrix.os == 'windows-2019'
+      name: Windows Dependencies
+      run: |
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
+        echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        scoop install llvm yasm
+    - name: Build
+      run: cargo build --release
+    - name: Get the Version
+      id: get_version
+      shell: bash
+      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+    - id: get_package
+      name: Package
+      shell: bash
+      run: |
+        pkgname="ckb-light-client_${{ steps.get_version.outputs.VERSION }}-${{ matrix.pkg_suffix }}.tar.gz"
+        cp "target/release/ckb-light-client${{ matrix.bin_suffix }}" "ckb-light-client${{ matrix.bin_suffix }}"
+        tar czvf "${pkgname}" "ckb-light-client${{ matrix.bin_suffix }}"
+        echo ::set-output name=PKGNAME::${pkgname}
+    - name: Upload Release Asset
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        draft: true
+        files: |
+          ${{ steps.get_package.outputs.PKGNAME }}


### PR DESCRIPTION
[Link to the Preview.](https://github.com/yangby-cryptape/ckb-light-client/releases/tag/v0.1.0)