### PR TITLE
feat: skip asking proof if a header is verified for other peers

### DIFF
--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -208,6 +208,18 @@ impl LightClientProtocol {
                 return;
             }
 
+            // Skipped if the header is proved in other peers.
+            if let Some((peer_copied_from, prove_state)) =
+                self.peers().find_if_a_header_is_proved(last_header)
+            {
+                info!(
+                    "peer {}: copy prove state from peer {}",
+                    peer, peer_copied_from
+                );
+                self.peers().update_prove_state(peer, prove_state);
+                return;
+            }
+
             if let Some(content) = self.build_prove_request_content(&peer_state, last_header) {
                 trace!("peer {}: send get last state proof", peer);
                 let message = packed::LightClientMessage::new_builder()

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -798,6 +798,24 @@ impl Peers {
             .collect()
     }
 
+    pub(crate) fn find_if_a_header_is_proved(
+        &self,
+        header: &VerifiableHeader,
+    ) -> Option<(PeerIndex, ProveState)> {
+        self.inner.iter().find_map(|item| {
+            item.value()
+                .state
+                .get_prove_state()
+                .and_then(|prove_state| {
+                    if prove_state.is_same_as(header) {
+                        Some((*item.key(), prove_state.clone()))
+                    } else {
+                        None
+                    }
+                })
+        })
+    }
+
     pub(crate) fn get_best_proved_peers(&self, best_tip: &packed::Header) -> Vec<PeerIndex> {
         self.get_peers_which_are_proved()
             .into_iter()


### PR DESCRIPTION
Skip asking proof if a header is verified for other peers, just copy the prove state to current peer.