### PR TITLE
fix: an incorrect function to traverse grouped data

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -366,7 +366,7 @@ impl Storage {
             .map(|data| {
                 assert!(data.len() % 40 == 0);
                 let mut headers = Vec::with_capacity(data.len() / 40);
-                for part in data.windows(40) {
+                for part in data.chunks(40) {
                     let number = u64::from_le_bytes(part[0..8].try_into().unwrap());
                     let hash = Byte32::from_slice(&part[8..]).expect("byte32 block hash");
                     headers.push((number, hash));


### PR DESCRIPTION
If there are 2 values of the `(number, hash)` pair, then the data length is `40 * 2 == 80`.

- Call `slice.windows()` will get `41` values:
  - `[0..=39]`
  - `[1..=40]`
  - ... ...
  - `[40..=79]`

- Call `slice.chunks()` will get `2` values:
  - `[0..=39]`
  - `[40..=79]`