### PR TITLE
fix: the stored last n headers is less than expected

### DIFF
--- a/src/protocols/light_client/components/send_last_state.rs
+++ b/src/protocols/light_client/components/send_last_state.rs
@@ -45,7 +45,8 @@ impl<'a> SendLastStateProcess<'a> {
                 if let Some(prove_state) = peer_state.get_prove_state() {
                     if prove_state.is_parent_of(&last_state) {
                         trace!("peer {}: new last state could be trusted", self.peer);
-                        let child_prove_state = prove_state.new_child(last_state);
+                        let last_n_blocks = self.protocol.last_n_blocks() as usize;
+                        let child_prove_state = prove_state.new_child(last_state, last_n_blocks);
                         self.protocol
                             .update_prove_state_to_child(self.peer, child_prove_state);
                     }

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -182,11 +182,14 @@ impl ProveState {
         }
     }
 
-    pub(crate) fn new_child(&self, child_last_state: LastState) -> Self {
+    pub(crate) fn new_child(&self, child_last_state: LastState, last_n_blocks: usize) -> Self {
         let parent_header = self.get_last_header().header();
         let mut last_headers = self.last_headers.clone();
         let reorg_last_headers = self.reorg_last_headers.clone();
-        last_headers.remove(0);
+        // To avoid unlimited memory growth.
+        if last_headers.len() >= last_n_blocks {
+            last_headers.remove(0);
+        }
         last_headers.push(parent_header.clone());
         Self {
             last_state: child_last_state,

--- a/src/protocols/status.rs
+++ b/src/protocols/status.rs
@@ -75,6 +75,13 @@ macro_rules! return_if_failed {
     };
 }
 
+#[cfg(test)]
+impl Default for StatusCode {
+    fn default() -> Self {
+        StatusCode::OK
+    }
+}
+
 impl PartialEq for Status {
     fn eq(&self, other: &Self) -> bool {
         self.code == other.code

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -129,6 +129,17 @@ pub(crate) trait RunningChainExt: ChainExt {
         }
     }
 
+    fn mine_to_with<F: FnMut(packed::Block) -> BlockView>(
+        &self,
+        block_number: BlockNumber,
+        builder: F,
+    ) {
+        let chain_tip_number = self.shared().snapshot().tip_number();
+        if chain_tip_number < block_number {
+            self.mine_blocks_with((block_number - chain_tip_number) as usize, builder);
+        }
+    }
+
     fn mine_block<F: FnMut(packed::Block) -> BlockView>(&self, mut builder: F) -> BlockNumber {
         let block_template = self
             .shared()
@@ -156,6 +167,16 @@ pub(crate) trait RunningChainExt: ChainExt {
     fn mine_blocks(&self, blocks_count: usize) {
         for _ in 0..blocks_count {
             let _ = self.mine_block(|block| block.as_advanced_builder().build());
+        }
+    }
+
+    fn mine_blocks_with<F: FnMut(packed::Block) -> BlockView>(
+        &self,
+        blocks_count: usize,
+        mut builder: F,
+    ) {
+        for _ in 0..blocks_count {
+            let _ = self.mine_block(&mut builder);
         }
     }
 

--- a/src/tests/utils/mod.rs
+++ b/src/tests/utils/mod.rs
@@ -1,3 +1,6 @@
+use env_logger::{Builder, Target};
+use log::LevelFilter;
+
 mod chain;
 mod network_context;
 
@@ -5,6 +8,16 @@ pub(crate) use chain::MockChain;
 pub(crate) use network_context::MockNetworkContext;
 
 use crate::storage::Storage;
+
+pub(crate) fn setup() {
+    let _ = Builder::new()
+        .filter_module("ckb_stop_handler", LevelFilter::Off)
+        .filter_module("ckb_light_client", LevelFilter::Trace)
+        .target(Target::Stdout)
+        .is_test(true)
+        .try_init();
+    println!();
+}
 
 pub(crate) fn new_storage(prefix: &str) -> Storage {
     let tmp_dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();


### PR DESCRIPTION
### Issue

Let $N_{last}$ denote the constant `LAST_N_BLOCKS`.

Suppose there are follow steps:

- Start a light client `C`.

- `C` connected to a CKB node `N`.

- `C` gets last state of block $h_{1}$ and its proof from `N`.

  And `C` saves $N_{last}$ last-N headers in its storage.

- The last state from `N` changes to $h_{2}$ with $h_{2}  = h_{1} + t$ and $N_{last} \gt t \gt 1$.

The bug is:

- When `C` updates the last state from $h_{1}$ to $h_{2}$, the count of saved last-N headers in the storage will changed to $t$.

- Then, if $t$ is too small, it will be difficult to find the ancestor block for a fork chain.

- So long fork will be detected frequently.

### Updates

- When add proved blocks, 

  - if the count of new last N headers is **less than** the expected count of the last N blocks, just **copy some old last N headers** to make sure we have enough stored last N headers.

  - if the count of new last N headers is **greater than** the expected count of the last N blocks, just **remove some of them** to avoid unlimited memory growth.

- Refactor unit tests to make it easier to add an `assert` to several unit tests, not just copy the code several times.

  And also add more unit tests to improve the coverage.

Resolve #117.