### PR TITLE
fix: long fork could NOT be detected in full sampling turn

### DIFF
--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -236,45 +236,46 @@ impl<'a> SendLastStateProofProcess<'a> {
                 reorg_last_headers,
                 last_headers,
             );
+
+            if original_request.if_long_fork_detected() {
+                error!(
+                    "Long fork detected, please check if ckb-light-client is connected to \
+                     the same network ckb node. If you connected ckb-light-client to a dev \
+                     chain for testing purpose you should remove the storage of \
+                     ckb-light-client to recover."
+                );
+                panic!("long fork detected");
+            }
+
             let long_fork_detected = !self
                 .protocol
                 .commit_prove_state(self.peer, prove_state.clone());
 
             if long_fork_detected {
-                if original_request.if_require_full_sampling() {
-                    error!(
-                        "Long fork detected, please check if ckb-light-client is connected to \
-                         the same network ckb node. If you connected ckb-light-client to a dev \
-                         chain for testing purpose you should remove the storage of \
-                         ckb-light-client to recover."
-                    );
-                    panic!("long fork detected");
+                let last_header = prove_state.get_last_header();
+                if let Some(content) = self
+                    .protocol
+                    .build_prove_request_content_from_genesis(last_header)
+                {
+                    let mut prove_request =
+                        ProveRequest::new(LastState::new(last_header.clone()), content.clone());
+                    prove_request.long_fork_detected();
+                    self.protocol
+                        .peers()
+                        .update_prove_request(self.peer, Some(prove_request));
+
+                    let message = packed::LightClientMessage::new_builder()
+                        .set(content)
+                        .build();
+                    self.nc.reply(self.peer, &message);
+
+                    let errmsg = "long fork detected";
+                    return StatusCode::RequireRecheck.with_context(errmsg);
                 } else {
-                    let last_header = prove_state.get_last_header();
-                    if let Some(content) = self
-                        .protocol
-                        .build_prove_request_content_from_genesis(last_header)
-                    {
-                        let mut prove_request =
-                            ProveRequest::new(LastState::new(last_header.clone()), content.clone());
-                        prove_request.require_full_sampling();
-                        self.protocol
-                            .peers()
-                            .update_prove_request(self.peer, Some(prove_request));
-
-                        let message = packed::LightClientMessage::new_builder()
-                            .set(content)
-                            .build();
-                        self.nc.reply(self.peer, &message);
-
-                        let errmsg = "long fork detected";
-                        return StatusCode::RequireRecheck.with_context(errmsg);
-                    } else {
-                        warn!(
-                            "peer {}, build prove request from genesis failed",
-                            self.peer
-                        );
-                    }
+                    warn!(
+                        "peer {}, build prove request from genesis failed",
+                        self.peer
+                    );
                 }
             }
         }

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -66,7 +66,7 @@ pub(crate) struct ProveRequest {
     last_state: LastState,
     content: packed::GetLastStateProof,
     skip_check_tau: bool,
-    require_full_sampling: bool,
+    long_fork_detected: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -145,7 +145,7 @@ impl ProveRequest {
             last_state,
             content,
             skip_check_tau: false,
-            require_full_sampling: false,
+            long_fork_detected: false,
         }
     }
 
@@ -169,12 +169,12 @@ impl ProveRequest {
         self.skip_check_tau = true;
     }
 
-    pub(crate) fn if_require_full_sampling(&self) -> bool {
-        self.require_full_sampling
+    pub(crate) fn if_long_fork_detected(&self) -> bool {
+        self.long_fork_detected
     }
 
-    pub(crate) fn require_full_sampling(&mut self) {
-        self.require_full_sampling = true;
+    pub(crate) fn long_fork_detected(&mut self) {
+        self.long_fork_detected = true;
     }
 }
 


### PR DESCRIPTION
Update the process when long fork detected.

```diff
  - Turn 1: verify a proof for incremental blocks on a fork chain.
    - Get a forked last state from a CKB node.
    - All checks for the proof are correct.
    - Compare the reorg blocks from forked last state proof and last N blocks in storage.
    - If no ancestor blocks was found, send a request to ask proof for the whole forked chain.
  - Turn 2: do full sampling on the whole chain.
    - All checks for the proof are correct.
-   - Compare the reorg blocks from forked last state proof and last N blocks in storage.
-   - If no ancestor blocks was found, panic.
+   - Panic.
```

If the a chain has the flag and it is valid, just panic!
All other checks are redundant.

Ref: #125