### PR TITLE
fix: limit the peer states which requires new last state

### DIFF
--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1005,9 +1005,15 @@ impl PeerState {
     }
 
     fn require_new_last_state(&self, before_ts: u64) -> bool {
-        self.get_last_state()
-            .map(|last_state| last_state.update_ts < before_ts)
-            .unwrap_or(true)
+        match self {
+            Self::Initialized => true,
+            Self::Ready { ref last_state, .. } => last_state.update_ts < before_ts,
+            Self::OnlyHasLastState { .. }
+            | Self::RequestFirstLastState { .. }
+            | Self::RequestFirstLastStateProof { .. }
+            | Self::RequestNewLastState { .. }
+            | Self::RequestNewLastStateProof { .. } => false,
+        }
     }
 
     fn require_new_last_state_proof(&self) -> bool {


### PR DESCRIPTION
Base on the design of state conversion as follows:
https://github.com/nervosnetwork/ckb-light-client/blob/dfa4f43b191ca619642969b0a9d5a46f35cb8031/src/protocols/light_client/peers.rs#L76-L96

Only two peer states allow requesting new last state:
https://github.com/nervosnetwork/ckb-light-client/blob/dfa4f43b191ca619642969b0a9d5a46f35cb8031/src/protocols/light_client/peers.rs#L881-L903