### PR TITLE
chore: tweak log levels and add logs

### DIFF
--- a/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/src/protocols/light_client/components/send_last_state_proof.rs
@@ -81,6 +81,18 @@ impl<'a> SendLastStateProofProcess<'a> {
             .collect::<Vec<VerifiableHeader>>();
         let last_n_blocks = self.protocol.last_n_blocks() as usize;
 
+        trace!(
+            "peer {}: last_number: {}, last_hash: {:#x}, headers_count: {}, last_n_config: {last_n_blocks}",
+            self.peer_index,
+            last_header.header().number(),
+            last_header.header().hash(),
+            headers.len(),
+        );
+
+        if log_enabled!(Level::Trace) {
+            print_headers(&headers);
+        }
+
         // Check if the response is match the request.
         let (reorg_count, sampled_count, last_n_count) =
             return_if_failed!(check_if_response_is_matched(
@@ -695,7 +707,7 @@ pub(crate) fn check_if_response_is_matched(
             headers[reorg_count + sampled_count].total_difficulty();
 
         if log_enabled!(Level::Trace) {
-            output_debug_messages(prev_request, headers, &first_last_n_total_difficulty);
+            print_difficulties_distribution(prev_request, headers, &first_last_n_total_difficulty);
         }
 
         let mut difficulties: Vec<U256> = prev_request
@@ -785,7 +797,17 @@ pub(crate) fn check_if_response_is_matched(
     Ok((reorg_count, sampled_count, last_n_count))
 }
 
-fn output_debug_messages(
+fn print_headers(headers: &[VerifiableHeader]) {
+    debug!("all headers in response:");
+    for h in headers {
+        let number = h.header().number();
+        let hash = h.header().number();
+        debug!(">>> header {number:9}: {hash:#x}");
+    }
+    debug!("all headers in response finished.");
+}
+
+fn print_difficulties_distribution(
     prev_request: &packed::GetLastStateProof,
     headers: &[VerifiableHeader],
     last_n_start: &U256,

--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -222,9 +222,10 @@ impl LightClientProtocol {
             if let Some((peer_index_copied_from, prove_state)) =
                 self.peers().find_if_a_header_is_proved(last_header)
             {
-                info!(
+                trace!(
                     "peer {}: copy prove state from peer {}",
-                    peer_index, peer_index_copied_from
+                    peer_index,
+                    peer_index_copied_from
                 );
                 self.peers().update_prove_state(peer_index, prove_state)?;
                 return Ok(false);
@@ -683,7 +684,7 @@ impl LightClientProtocol {
                 .update_check_points(last_cpindex + 1, &check_points[1..=index]);
             self.storage.update_max_check_point_index(new_last_cpindex);
         } else {
-            info!("no check point is found which could be finalized");
+            trace!("no check point is found which could be finalized");
         }
     }
 


### PR DESCRIPTION
- tweak log levels
  
  After light client reaches the latest block, then:
  - If it has `N` peers, `copy prove state from peer` will be output `N-1` times for every block.
  - `no check point is found` will be output `1999` times per `2000` blocks.
  So, change levels for those logs to `trace`.

- add logs

  At present, if `trace` logs are enabled, only the block numbers are output when print difficulties distribution.

  So, print block hashes at function entry.