### PR TITLE
fix: panic when no enough block filter hashes

### DIFF
--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -156,6 +156,17 @@ impl<'a> BlockFiltersProcess<'a> {
                     (finalized_check_point_hash, latest_block_filter_hashes)
                 } else {
                     let start_index = (start_number - finalized_check_point_number) as usize - 2;
+                    if start_index >= latest_block_filter_hashes.len() {
+                        info!(
+                            "ignoring, no enough data for block filter hashes, \
+                            finalized number: {finalized_check_point_number}, \
+                            finalized index: {finalized_check_point_index}, \
+                            start number: {start_number}, start index: {start_index}, \
+                            filter hashes length {}",
+                            latest_block_filter_hashes.len()
+                        );
+                        return Status::ok();
+                    }
                     let parent_hash = latest_block_filter_hashes[start_index].clone();
                     latest_block_filter_hashes.drain(..=start_index);
                     (parent_hash, latest_block_filter_hashes)

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -727,7 +727,6 @@ async fn test_block_filter_notify_recover_matched_blocks() {
     );
 }
 
-#[should_panic(expected = "index out of bounds: the len is 0 but the index is")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_block_filter_without_enough_hashes() {
     setup();

--- a/src/tests/protocols/block_filter.rs
+++ b/src/tests/protocols/block_filter.rs
@@ -726,3 +726,97 @@ async fn test_block_filter_notify_recover_matched_blocks() {
         ]
     );
 }
+
+#[should_panic(expected = "index out of bounds: the len is 0 but the index is")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_filter_without_enough_hashes() {
+    setup();
+
+    let chain = MockChain::new_with_dummy_pow("test-block-filter").start();
+    let nc = MockNetworkContext::new(SupportProtocols::Filter);
+
+    let min_filtered_block_number = 30;
+    let start_number = min_filtered_block_number + 1;
+    let proved_number = start_number + 5;
+    let script = Script::new_builder()
+        .code_hash(H256(rand::random()).pack())
+        .build();
+    chain.client_storage().update_filter_scripts(
+        vec![ScriptStatus {
+            script: script.clone(),
+            script_type: ScriptType::Lock,
+            block_number: 0,
+        }],
+        SetScriptsCommand::All,
+    );
+    chain
+        .client_storage()
+        .update_min_filtered_block_number(min_filtered_block_number);
+
+    chain.mine_to(start_number - 3);
+
+    {
+        let tx = {
+            let tx = chain.get_cellbase_as_input(start_number - 5);
+            let output = tx.output(0).unwrap().as_builder().lock(script).build();
+            tx.as_advanced_builder().set_outputs(vec![output]).build()
+        };
+        chain.mine_block(|block| {
+            let ids = vec![tx.proposal_short_id()];
+            block.as_advanced_builder().proposals(ids).build()
+        });
+        chain.mine_blocks(1);
+        chain.mine_block(|block| block.as_advanced_builder().transaction(tx.clone()).build());
+        chain.mine_blocks(1);
+    }
+
+    chain.mine_to(proved_number);
+
+    let snapshot = chain.shared().snapshot();
+
+    let tip_header: VerifiableHeader = snapshot
+        .get_verifiable_header_by_number(proved_number)
+        .expect("block stored")
+        .into();
+    chain
+        .client_storage()
+        .update_last_state(&U256::one(), &tip_header.header().data(), &[]);
+
+    let peer_index = PeerIndex::new(3);
+    let peers = {
+        let peers = chain.create_peers();
+        peers.add_peer(peer_index);
+        peers.mock_prove_state(peer_index, tip_header).unwrap();
+        peers.set_max_outbound_peers(3);
+        peers
+    };
+
+    let filter_data_1 = snapshot.get_block_filter_data(start_number).unwrap();
+    let filter_data_2 = snapshot.get_block_filter_data(start_number + 1).unwrap();
+    let block_hash_1 = snapshot.get_block_hash(start_number).unwrap();
+    let block_hash_2 = snapshot.get_block_hash(start_number + 1).unwrap();
+    let filter_hashes = {
+        let mut filter_hashes = snapshot
+            .get_block_filter_hashes_until(start_number + 3)
+            .unwrap();
+        filter_hashes.remove(0);
+        filter_hashes
+    };
+
+    let content = packed::BlockFilters::new_builder()
+        .start_number(start_number.pack())
+        .block_hashes(vec![block_hash_1.clone(), block_hash_2].pack())
+        .filters(vec![filter_data_1, filter_data_2].pack())
+        .build();
+    let message = packed::BlockFilterMessage::new_builder()
+        .set(content)
+        .build()
+        .as_bytes();
+
+    let mut protocol = chain.create_filter_protocol(Arc::clone(&peers));
+    peers.mock_latest_block_filter_hashes(peer_index, 0, filter_hashes);
+    protocol.received(nc.context(), peer_index, message).await;
+    assert!(nc.not_banned(peer_index));
+
+    assert!(nc.sent_messages().borrow().is_empty());
+}


### PR DESCRIPTION
### Descriptions

- Split (or access) the `start_index`-th item of `latest_block_filter_hashes` without checks.

  https://github.com/nervosnetwork/ckb-light-client/blob/02721f38854ad0722347e8d132d31c173dd7cdaf/src/protocols/filter/components/block_filters_process.rs#L159-L160

- But `latest_block_filter_hashes` could be empty or less than `start_index`.

  https://github.com/nervosnetwork/ckb-light-client/blob/02721f38854ad0722347e8d132d31c173dd7cdaf/src/protocols/light_client/peers.rs#L1713-L1715

### Commits

- Add a test to reproduce the bug.

- Fix the bug.

  Review this commit could find the difference on the unit test easier.

  And could understand how does this bug happened and how to fix it easier.

- Add more logs.

### Error Logs

<details><summary>Full of the Error Logs</summary><br />

```
[2023-10-08T22:29:01Z TRACE ckb_light_client::protocols::status] LightClientProtocol.received SendLastStateProof from SessionId(7094), result OK(200)
[2023-10-08T22:29:01Z TRACE ckb_light_client::protocols::synchronizer] SyncProtocol.received peer=SessionId(6201), message=GetHeaders
[2023-10-08T22:29:02Z TRACE ckb_light_client::protocols::light_client] no fetching headers/transactions needed
[2023-10-08T22:29:02Z TRACE ckb_light_client::protocols::synchronizer] SyncProtocol.received peer=SessionId(23), message=GetHeaders
[2023-10-08T22:29:03Z TRACE ckb_light_client::protocols::filter::block_filter] could request block filters from 10888757 or not: true, finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:03Z DEBUG ckb_light_client::protocols::filter::block_filter] found best proved peer SessionId(9261)
[2023-10-08T22:29:03Z TRACE ckb_light_client::protocols::filter::block_filter] no block filters is required to download
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter hashes from peer SessionId(7094), starts at 10886001
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter hashes from peer SessionId(23), starts at 10888759
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter hashes from peer SessionId(9262), starts at 10888759
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter hashes from peer SessionId(9261), starts at 10888759
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] peer SessionId(9261): last-state: PeerState::Ready { last_state: 10888759 }, add block filter hashes (start: 10888759, len: 1) and parent block filter hash is 0xc5ca1bf9b62cc39580d3619bf33081c7ee38bbe3a3dbfcdd9fe740da14b35d51
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::status] BlockFilterProtocol.received BlockFilterHashes from SessionId(9261), result OK(200)
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] peer SessionId(9262): last-state: PeerState::Ready { last_state: 10888759 }, add block filter hashes (start: 10888759, len: 1) and parent block filter hash is 0xc5ca1bf9b62cc39580d3619bf33081c7ee38bbe3a3dbfcdd9fe740da14b35d51
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::status] BlockFilterProtocol.received BlockFilterHashes from SessionId(9262), result OK(200)
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] peer SessionId(23): last-state: PeerState::Ready { last_state: 10888759 }, add block filter hashes (start: 10888759, len: 1) and parent block filter hash is 0xc5ca1bf9b62cc39580d3619bf33081c7ee38bbe3a3dbfcdd9fe740da14b35d51
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:04Z TRACE ckb_light_client::protocols::status] BlockFilterProtocol.received BlockFilterHashes from SessionId(23), result OK(200)
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::light_client] no fetching headers/transactions needed
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] peer SessionId(7094): last-state: PeerState::Ready { last_state: 10888759 }, add block filter hashes (start: 10886001, len: 2000) and parent block filter hash is 0x5f388b30206fe7324bfaeec95ef15b7c791fe02d408a251aeba38d270eb3de5d
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter hashes from peer SessionId(7094), starts at 10888001
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::status] BlockFilterProtocol.received BlockFilterHashes from SessionId(7094), result OK(200)
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] peer SessionId(7094): last-state: PeerState::Ready { last_state: 10888759 }, add block filter hashes (start: 10888001, len: 759) and parent block filter hash is 0x5ecfac4d3328b6cc7f53d0d8c18bfc9d701d4fca4efc9e3cda80987ebe928c89
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::filter::components::block_filter_hashes_process] finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:05Z TRACE ckb_light_client::protocols::status] BlockFilterProtocol.received BlockFilterHashes from SessionId(7094), result OK(200)
[2023-10-08T22:29:06Z TRACE ckb_light_client::protocols::filter::block_filter] could request block filters from 10888757 or not: true, finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:06Z DEBUG ckb_light_client::protocols::filter::block_filter] found best proved peer SessionId(9261)
[2023-10-08T22:29:06Z TRACE ckb_light_client::protocols::filter::block_filter] no block filters is required to download
[2023-10-08T22:29:08Z TRACE ckb_light_client::protocols::light_client] no fetching headers/transactions needed
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::filter::block_filter] could request block filters from 10888757 or not: true, finalized: index 5443, number 10886000; cached: index 5444, number 10888000, length 0; next cached: number 10890000
[2023-10-08T22:29:09Z DEBUG ckb_light_client::protocols::filter::block_filter] found best proved peer SessionId(9261)
[2023-10-08T22:29:09Z DEBUG ckb_light_client::protocols::filter::block_filter] send get block filters to SessionId(9261), start_number=10888757
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::filter::block_filter] request block filter from peer SessionId(9261), starts at 10888757
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] peer SessionId(6201): copy prove state from peer SessionId(7094)
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] peer SessionId(2): copy prove state from peer SessionId(6201)
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] peer SessionId(9265): copy prove state from peer SessionId(6201)
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] peer SessionId(7097): copy prove state from peer SessionId(6201)
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(2) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(23) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(7097) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(7094) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(6201) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(9265) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(9262) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] check points for peer SessionId(9261) in [5443,5443]
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] requires 4 peers for finalizing check points and got 8
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] finalized check point is 5443, 0x5f388b30206fe7324bfaeec95ef15b7c791fe02d408a251aeba38d270eb3de5d
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] new last check point will be less than or equal to 5443
[2023-10-08T22:29:09Z TRACE ckb_light_client::protocols::light_client] no check point is found which could be finalized
thread 'GlobalRt-0' panicked at 'index out of bounds: the len is 0 but the index is 2755', src/protocols/filter/components/block_filters_process.rs:159:39
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2023-10-08T22:29:09Z INFO  ckb_network::network] Ban peer "/ip4/*.*.*.*/tcp/8111/p2p/***********************************************" for 300 seconds, reason: protocol ProtocolId(121) panic when process peer message
```

</details>