### PR TITLE
fix: should mark fetching status as timeout when disconnect

### DIFF
--- a/src/protocols/light_client/mod.rs
+++ b/src/protocols/light_client/mod.rs
@@ -6,7 +6,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use ckb_chain_spec::consensus::Consensus;
-use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
+use ckb_constant::{
+    hardfork::{mainnet, testnet},
+    sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+};
 use ckb_network::{
     async_trait, bytes::Bytes, CKBProtocolContext, CKBProtocolHandler, PeerIndex, SupportProtocols,
 };
@@ -409,11 +412,11 @@ impl LightClientProtocol {
 
 impl LightClientProtocol {
     pub(crate) fn new(storage: Storage, peers: Arc<Peers>, consensus: Consensus) -> Self {
-        // TODO remove this hard code when mmr is activated on testnet
-        let mmr_activated_epoch = if consensus.is_public_chain() {
-            EpochNumber::MAX
-        } else {
-            0
+        // Ref: https://github.com/nervosnetwork/rfcs/blob/01f3bc64ef8f54c94c7b0dcf9d30c84b6c8418b0/rfcs/0044-ckb-light-client/0044-ckb-light-client.md#deployment
+        let mmr_activated_epoch = match consensus.id.as_str() {
+            mainnet::CHAIN_SPEC_NAME => 8648,
+            testnet::CHAIN_SPEC_NAME => 5676,
+            _ => 0,
         };
         Self {
             storage,

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1260,6 +1260,8 @@ impl Peers {
     }
 
     pub(crate) fn remove_peer(&self, index: PeerIndex) {
+        self.mark_fetching_headers_timeout(index);
+        self.mark_fetching_txs_timeout(index);
         self.inner.remove(&index);
     }
 

--- a/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -525,6 +525,6 @@ async fn test_send_headers_txs_request() {
     protocol.disconnected(nc.context(), peer_index).await;
     protocol.notify(nc.context(), REFRESH_PEERS_TOKEN).await;
 
-    assert_eq!(peers.get_txs_to_fetch().len(), 0);
-    assert_eq!(peers.get_headers_to_fetch().len(), 0);
+    assert_eq!(peers.get_txs_to_fetch().len(), 1);
+    assert_eq!(peers.get_headers_to_fetch().len(), 1);
 }


### PR DESCRIPTION
### Commits

- fix: should mark fetching status as timeout when disconnect
- test: reproduce the bug that state is dirty after unexpected disconnection