### PR TITLE
fix: stuck after restart when min filtered block is previous block of a check point

### DIFF
--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -95,11 +95,13 @@ impl FilterProtocol {
         nc: Arc<dyn CKBProtocolContext + Sync>,
         immediately: bool,
     ) {
-        let start_number = self.storage.get_min_filtered_block_number() + 1;
+        let min_filtered_block_number = self.storage.get_min_filtered_block_number();
+        let start_number = min_filtered_block_number + 1;
         let (finalized_check_point_index, _) = self.storage.get_last_check_point();
-        let could_ask_more = self
-            .peers
-            .could_request_more_block_filters(finalized_check_point_index, start_number);
+        let could_ask_more = self.peers.could_request_more_block_filters(
+            finalized_check_point_index,
+            min_filtered_block_number,
+        );
         if log_enabled!(Level::Trace) {
             let finalized_check_point_number = self
                 .peers
@@ -113,9 +115,9 @@ impl FilterProtocol {
                 .calc_check_point_number(cached_check_point_index + 1);
             trace!(
                 "could request block filters from {} or not: {}, \
-                         finalized: index {}, number {}; \
-                         cached: index {}, number {}, length {}; \
-                         next cached: number {}",
+                finalized: index {}, number {}; \
+                cached: index {}, number {}, length {}; \
+                next cached: number {}",
                 start_number,
                 could_ask_more,
                 finalized_check_point_index,

--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -253,10 +253,10 @@ impl<'a> BlockFiltersProcess<'a> {
         self.filter
             .update_min_filtered_block_number(filtered_block_number);
 
-        let could_request_more_block_filters = self.filter.peers.could_request_more_block_filters(
-            finalized_check_point_index,
-            filtered_block_number + 1,
-        );
+        let could_request_more_block_filters = self
+            .filter
+            .peers
+            .could_request_more_block_filters(finalized_check_point_index, filtered_block_number);
         if could_request_more_block_filters {
             // send next batch GetBlockFilters message to a random best peer
             let best_peer = self


### PR DESCRIPTION
### Changes

- In the following code:

  https://github.com/nervosnetwork/ckb-light-client/blob/38aa9b200be7c6b96ded79bf3d2f84b157f2d230/src/protocols/light_client/peers.rs#L1606-L1608

  `min_filtered_block_number` is the last filtered block which has been synchronized.

  `should_cached_check_point_index` is the index of the check point, which contains the next filtered block which will be synchronized.

  So, the it should be fixed with following patch:

  ```diff
    pub(crate) fn update_min_filtered_block_number(&self, min_filtered_block_number: BlockNumber) { 
        let should_cached_check_point_index = 
  -         self.calc_best_check_point_index_not_greater_than(min_filtered_block_number); 
  +         self.calc_best_check_point_index_not_greater_than(min_filtered_block_number + 1); 
  ```

- See the following code:

  https://github.com/nervosnetwork/ckb-light-client/blob/38aa9b200be7c6b96ded79bf3d2f84b157f2d230/src/protocols/light_client/peers.rs#L1141-L1143

  At start, the check point index and the block number of it is `0, 0`.

  The following check point index and the block number of it are `1, 2000`, `2, 4000` and son on.

  When the client want to synchronizes the block `2000`，the last check point should be `0`.

  When the client want to synchronizes the block `2001` to `4000`，the last check point should be `1`.

  So, when client synchronizes the filtered block `number`, the check point should be:

  ```diff
  -         (number / self.check_point_interval) as u32 
  +         (number.saturating_sub(1) / self.check_point_interval) as u32
  ```

- Changed some naming to make the names are more appropriate.