### PR TITLE
fix: resolve update script block number error

### DIFF
--- a/src/protocols/filter/components/block_filters_process.rs
+++ b/src/protocols/filter/components/block_filters_process.rs
@@ -54,6 +54,13 @@ impl<'a> BlockFiltersProcess<'a> {
             return Status::ok();
         };
 
+        let mut matched_blocks = self
+            .filter
+            .peers
+            .matched_blocks()
+            .write()
+            .expect("poisoned");
+
         let block_filters = self.message.to_entity();
         let start_number: BlockNumber = block_filters.start_number().unpack();
         let filters_count = block_filters.filters().len();
@@ -212,12 +219,6 @@ impl<'a> BlockFiltersProcess<'a> {
         let tip_header = self.filter.storage.get_tip_header();
         let filtered_block_number = start_number - 1 + actual_blocks_count as BlockNumber;
 
-        let mut matched_blocks = self
-            .filter
-            .peers
-            .matched_blocks()
-            .write()
-            .expect("poisoned");
         if possible_match_blocks_len != 0 {
             let blocks = possible_match_blocks
                 .iter()


### PR DESCRIPTION
we are using the `matched_blocks` lock to avoiding concurrent update scrtips' filtered block number:
https://github.com/nervosnetwork/ckb-light-client/blob/89be07042a7d01688ebac89b1c7b2c56bec791b6/src/service.rs#L403

however, the lock scope is too small when processing the `BlockFilters` message, it results in concurrent updates to the same scripts' filtered block number: 
https://github.com/nervosnetwork/ckb-light-client/blob/89be07042a7d01688ebac89b1c7b2c56bec791b6/src/protocols/filter/components/block_filters_process.rs#L215