### PR TITLE
fix: ban peers when do reorg after client restart

### DIFF
--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1286,6 +1286,13 @@ impl Peers {
     }
 
     #[cfg(test)]
+    pub(crate) fn mock_initialized(&self, index: PeerIndex) {
+        if let Some(mut peer) = self.inner.get_mut(&index) {
+            _ = peer.state.take();
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn mock_prove_request(
         &self,
         index: PeerIndex,

--- a/src/tests/protocols/light_client/send_last_state_proof.rs
+++ b/src/tests/protocols/light_client/send_last_state_proof.rs
@@ -1653,7 +1653,6 @@ async fn reorg_rollback_after_restart_and_last_n_blocks_is_not_enough() {
         last_number: 30,
         rollback_blocks_count: 3,
         last_n_blocks: 20,
-        result: StatusCode::InvalidReorgHeaders,
         restart: true,
         ..Default::default()
     };


### PR DESCRIPTION
### Description

This PR will fix #145.

If the first new "last state" after light client restarted is a fork state, the light client will do reorg to change its state to the new chain.

Let's denote
- the number of old "last state" as $n_{old}$.
- the number of new "last state" as $n_{new}$.
- the parameter [`LAST_N_BLOCKS`] as $N$.

The blocks before $n_{old}$ (included) are called as "reorg blocks", "reorg blocks" must be continuous.
The last n **continuous** blocks before $n_{new}$ (included) are called as "last n blocks"; non-continuous blocks are "sampled blocks".

If the restart is too soon, $n_{new} - n_{old} < N$, the "last n blocks" will not enough, then light client will throw the error [`InvalidReorgHeaders`](https://github.com/nervosnetwork/ckb-light-client/blob/e0a060a79190a606d0b7bc04bb211c1464444e6a/src/protocols/light_client/components/send_last_state_proof.rs#L268C44-L268C63) and ban the peer who sent the proof.

#### How to fix?

If light client received all blocks between the fork block to the new "last state", then light client could use the reorg blocks to fill the "last n blocks".

### Commits

- test: reproduce the bug that peers will be banned when do reorg after client restart
- fix: ban peers when do reorg after client restart

[`LAST_N_BLOCKS`]: https://github.com/nervosnetwork/ckb-light-client/blob/e0a060a79190a606d0b7bc04bb211c1464444e6a/src/protocols/mod.rs#L28