### PR TITLE
fix: don't sync block filter hashes if finalized checkpoint is too less than the last proved header

### DIFF
--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1723,7 +1723,9 @@ impl Peers {
                     if check_point_number == finalized_check_point_number {
                         let proved_number = state.get_last_header().header().number();
                         let last_number = latest_block_filter_hashes.get_last_number();
-                        if last_number < proved_number {
+                        if last_number < proved_number
+                            && proved_number - last_number < self.check_point_interval * 2
+                        {
                             Some((*peer_index, last_number + 1))
                         } else {
                             None


### PR DESCRIPTION
Why `< self.check_point_interval * 2`?

https://github.com/nervosnetwork/ckb-light-client/blob/fc45e35cd3ce40fae5762daa97e4c89991094262/src/protocols/light_client/peers.rs#L539-L541

Because light client don't finalize the latest checkpoint, light client will keep a checkpoint as a safe distance, so it doesn't have to rollback such many blocks even there is a fork. _(N.B. Light client won't handle a long fork.)_

- If the last number is $N$, denote `check_point_interval` as $I$, light client will use the $(| \frac{N-I+1}{I}| - 1)\mathrm{-th}$ checkpoint as finalized checkpoint if there are more than  $\frac{1}{2}\mathrm{MAX\\_OUTBOUND\\_PEERS}$ peers have this checkpoint.
- Before the finalized checkpoint (include), light client will only sync all checkpoints.
- After the finalized checkpoint, light client will sync all block filter hashes.

So, as **an approximated value**, I use `< self.check_point_interval * 2` here.

Ref: the 2nd issue in https://github.com/nervosnetwork/ckb-light-client/issues/168#issuecomment-1871169613.