### PR TITLE
feat: ban a peer if its last state isn't changed after timeout

### DIFF
--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -249,6 +249,15 @@ impl LastState {
     pub(crate) fn header(&self) -> &HeaderView {
         self.as_ref().header()
     }
+
+    pub(crate) fn update_ts(&self) -> u64 {
+        self.update_ts
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_same_as(&self, another: &Self) -> bool {
+        if_verifiable_headers_are_same(&self.header, &another.header)
+    }
 }
 
 impl fmt::Display for ProveRequest {
@@ -1025,7 +1034,7 @@ impl PeerState {
     fn require_new_last_state(&self, before_ts: u64) -> bool {
         match self {
             Self::Initialized => true,
-            Self::Ready { ref last_state, .. } => last_state.update_ts < before_ts,
+            Self::Ready { ref last_state, .. } => last_state.update_ts() < before_ts,
             Self::OnlyHasLastState { .. }
             | Self::RequestFirstLastState { .. }
             | Self::RequestFirstLastStateProof { .. }

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1857,6 +1857,15 @@ impl Peers {
                         }
                     })
                     .or_else(|| {
+                        peer.state.get_last_state().and_then(|state| {
+                            if now > state.update_ts + MESSAGE_TIMEOUT {
+                                Some(*peer_index)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .or_else(|| {
                         peer.get_blocks_proof_request().and_then(|req| {
                             if now > req.when_sent + MESSAGE_TIMEOUT {
                                 Some(*peer_index)

--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -254,7 +254,6 @@ impl LastState {
         self.update_ts
     }
 
-    #[cfg(test)]
     pub(crate) fn is_same_as(&self, another: &Self) -> bool {
         if_verifiable_headers_are_same(&self.header, &another.header)
     }

--- a/src/tests/protocols/light_client/send_last_state.rs
+++ b/src/tests/protocols/light_client/send_last_state.rs
@@ -215,8 +215,7 @@ async fn update_to_same_last_state() {
         let last_state_after = peer_state_after.get_last_state().expect("has last state");
 
         assert!(last_state_after.is_same_as(&last_state_before));
-        // TODO keep the update timestamp if the last state is not changed
-        assert_ne!(last_state_after.update_ts(), last_state_before.update_ts());
+        assert_eq!(last_state_after.update_ts(), last_state_before.update_ts());
     }
 }
 


### PR DESCRIPTION
### Description

If a peer sent the same state to light client again and again, light client should ban it.

Just let the light client don't update the update timestamp for cached last-state if it isn't changed, and ban the peer when do timeout checks.

https://github.com/nervosnetwork/ckb-light-client/blob/86865dbb450753e73c5755a75e52b779231a3114/src/protocols/light_client/mod.rs#L502-L507

https://github.com/nervosnetwork/ckb-light-client/blob/86865dbb450753e73c5755a75e52b779231a3114/src/protocols/mod.rs#L25-L26

### Commits:
- test: test the cached state when received same last state from a peer more than once
- feat: keep the update timestamp if the last state is as the same as the previous
- feat: ban a peer if its last state isn't changed after timeout