### PR TITLE
fix: refresh last state even no proved state

### DIFF
--- a/src/protocols/light_client/peers.rs
+++ b/src/protocols/light_client/peers.rs
@@ -1033,9 +1033,10 @@ impl PeerState {
     fn require_new_last_state(&self, before_ts: u64) -> bool {
         match self {
             Self::Initialized => true,
-            Self::Ready { ref last_state, .. } => last_state.update_ts() < before_ts,
-            Self::OnlyHasLastState { .. }
-            | Self::RequestFirstLastState { .. }
+            Self::OnlyHasLastState { ref last_state } | Self::Ready { ref last_state, .. } => {
+                last_state.update_ts() < before_ts
+            }
+            Self::RequestFirstLastState { .. }
             | Self::RequestFirstLastStateProof { .. }
             | Self::RequestNewLastState { .. }
             | Self::RequestNewLastStateProof { .. } => false,


### PR DESCRIPTION
### Description

Currently, the light client only refreshes the last state after it has a proved last state.
But, if it has sent a worse state to the light client (worse than saved state), the light client won't ask its last state proof.

The light client should ask it for a new last state.