### PR TITLE
ci: remove deprecated dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,36 +14,26 @@ jobs:
     name: Checks / Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --profile minimal --component rustfmt
+          rustup override set ${{ env.RUST_TOOLCHAIN }}
+      - name: Format Check
+        run: make fmt
   clippy:
     name: Checks / Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --locked -- --deny warnings
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --profile minimal --component clippy
+          rustup override set ${{ env.RUST_TOOLCHAIN }}
+      - name: Lint Check
+        run: make clippy
   test:
     name: Tests / Build & Test
     needs: [ rustfmt, clippy ]
@@ -52,24 +42,26 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: taiki-e/install-action@nextest
-    - if: matrix.os == 'windows-2019'
-      name: Windows Dependencies
-      run: |
-        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
-        .\install-scoop.ps1 -RunAsAdmin
-        echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        scoop install llvm yasm
-    - name: Build
-      run: cargo build
-    - if: matrix.os != 'macos-latest'
-      name: UnitTest
-      run: make test
-    - if: matrix.os == 'macos-latest'
-      name: UnitTest
-      run: make test-portable
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - name: Windows Dependencies
+        if: matrix.os == 'windows-2019'
+        run: |
+          iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+          .\install-scoop.ps1 -RunAsAdmin
+          echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          scoop install llvm yasm
+      - name: Build
+        run: make build
+      - name: UnitTest
+        if: matrix.os != 'macos-latest'
+        run: make test
+      - name: UnitTest
+        if: matrix.os == 'macos-latest'
+        run: make test-portable
   code_coverage:
     name: Code Coverage
     needs: [ test ]
@@ -80,17 +72,14 @@ jobs:
     env:
       OS: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: llvm-tools-preview
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --profile minimal
+          rustup override set ${{ env.RUST_TOOLCHAIN }}
       - name: Install Grcov
-        run: grcov --version || cargo install --locked grcov
+        run: make coverage-install-tools
       - name: Generate Code Coverage Report of Unit Tests
         run: |
           make coverage-run-unittests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,12 +30,12 @@ jobs:
             bin_suffix: .exe
             pkg_suffix: x86_64-windows
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        override: true
+    - name: Checkout the Repository
+      uses: actions/checkout@v4
+    - name: Install Rust Toolchain
+      run: |
+        rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --profile minimal
+        rustup override set ${{ env.RUST_TOOLCHAIN }}
     - if: matrix.os == 'windows-2019'
       name: Windows Dependencies
       run: |
@@ -81,7 +81,7 @@ jobs:
     - name: Get the Version
       id: get_version
       shell: bash
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
     - id: get_package
       name: Package
       shell: bash
@@ -89,7 +89,7 @@ jobs:
         pkgname="ckb-light-client_${{ steps.get_version.outputs.VERSION }}-${{ matrix.pkg_suffix }}.tar.gz"
         cp "target/release/ckb-light-client${{ matrix.bin_suffix }}" "ckb-light-client${{ matrix.bin_suffix }}"
         tar czvf "${pkgname}" "ckb-light-client${{ matrix.bin_suffix }}" "config"
-        echo ::set-output name=PKGNAME::${pkgname}
+        echo "PKGNAME=${pkgname}" >> $GITHUB_OUTPUT
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       env:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ GRCOV_EXCL_START = ^\s*((log::)?(trace|debug|info|warn|error)|(debug_)?assert(_e
 GRCOV_EXCL_STOP  = ^\s*\)(;)?$$
 GRCOV_EXCL_LINE = \s*((log::)?(trace|debug|info|warn|error)|(debug_)?assert(_eq|_ne|_error_eq))!\(.*\)(;)?$$
 
+fmt:
+	cargo fmt --all --check
+
+clippy:
+	cargo clippy --workspace --locked -- --deny warnings
+
+build:
+	cargo build
+
 test:
 	cargo nextest run --hide-progress-bar --success-output immediate --failure-output immediate
 


### PR DESCRIPTION
### Updates

- For all workflow scripts:

  - `actions/checkout`: `v2 -> v4`.

  - Remove `actions-rs/*` because actions-rs/toolchain#216 since 2022-06.

- For `release.yaml`:

  - [2022-10-11: The `set-output` command is deprecated and will be disabled soon.](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

    Examples:
    ```diff
    - run: echo "::set-output name={name}::{value}"
    + run: echo "{name}={value}" >> $GITHUB_OUTPUT
    ```