### PR TITLE
fix: download matched blocks even previous download are not finished

### DIFF
--- a/src/protocols/filter/block_filter.rs
+++ b/src/protocols/filter/block_filter.rs
@@ -142,7 +142,7 @@ impl FilterProtocol {
             {
                 debug!(
                     "try recover matched blocks from storage, start_number={}, \
-                             blocks_count={}, matched_count: {}",
+                    blocks_count={}, matched_count: {}",
                     db_start_number,
                     blocks_count,
                     matched_blocks.len(),
@@ -151,21 +151,21 @@ impl FilterProtocol {
                     // recover matched blocks from storage
                     self.peers
                         .add_matched_blocks(&mut matched_blocks, db_blocks);
-                    let tip_header = self.storage.get_tip_header();
-                    prove_or_download_matched_blocks(
-                        Arc::clone(&self.peers),
-                        &tip_header,
-                        &matched_blocks,
-                        nc.as_ref(),
-                        INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+                }
+                let tip_header = self.storage.get_tip_header();
+                prove_or_download_matched_blocks(
+                    Arc::clone(&self.peers),
+                    &tip_header,
+                    &matched_blocks,
+                    nc.as_ref(),
+                    INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+                );
+                if could_ask_more {
+                    debug!(
+                        "send get block filters to {}, start_number={}",
+                        peer, start_number
                     );
-                    if could_ask_more {
-                        debug!(
-                            "send get block filters to {}, start_number={}",
-                            peer, start_number
-                        );
-                        self.send_get_block_filters(nc, *peer, start_number);
-                    }
+                    self.send_get_block_filters(nc, *peer, start_number);
                 }
             } else if self.should_ask(immediately) && could_ask_more {
                 debug!(


### PR DESCRIPTION
### Issue

If the matched blocks in memory are not empty, but the matched blocks in storage are not empty, the download process will hang.

<details><summary>This logic is existed since 2022 without changes.</summary>

https://github.com/nervosnetwork/ckb-light-client/blob/09b9ae5b9dc723ce9a720aeec0d017ba8f78586b/src/protocols/filter/block_filter.rs#L200-L228

</details>

Ref: #77

### Solution

After reading the code, in my understanding:
- When a set of new possible matched blocks is found, it will be added into storage.
- If the set of matched blocks in memory is empty, load the earliest set of possible matched blocks from storage.
- If all matched blocks in memory are downloaded, then clear the memory.

So, `prove_or_download_matched_blocks(..)` should be executed when memory are not empty.  