### PR TITLE
fix panic caused by scope of  `matched_blocks` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-light-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ckb-async-runtime",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-light-client-lib"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ckb-app-config",

--- a/light-client-bin/Cargo.toml
+++ b/light-client-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/light-client-bin/src/rpc.rs
+++ b/light-client-bin/src/rpc.rs
@@ -135,7 +135,7 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
         scripts: Vec<ScriptStatus>,
         command: Option<SetScriptsCommand>,
     ) -> Result<()> {
-        let mut matched_blocks = self.swc.matched_blocks().write().expect("poisoned");
+        let mut matched_blocks = self.swc.matched_blocks().blocking_write();
         let scripts = scripts.into_iter().map(Into::into).collect();
         self.swc
             .storage()

--- a/light-client-bin/src/rpc.rs
+++ b/light-client-bin/src/rpc.rs
@@ -135,12 +135,18 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
         scripts: Vec<ScriptStatus>,
         command: Option<SetScriptsCommand>,
     ) -> Result<()> {
-        let mut matched_blocks = self.swc.matched_blocks().blocking_write();
-        let scripts = scripts.into_iter().map(Into::into).collect();
-        self.swc
-            .storage()
-            .update_filter_scripts(scripts, command.map(Into::into).unwrap_or_default());
-        matched_blocks.clear();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let swc = self.swc.clone();
+        std::thread::spawn(move || {
+            let mut matched_blocks = swc.matched_blocks().blocking_write();
+            let scripts = scripts.into_iter().map(Into::into).collect();
+            swc
+                .storage()
+                .update_filter_scripts(scripts, command.map(Into::into).unwrap_or_default());
+            matched_blocks.clear();
+            tx.send(()).unwrap();
+        });
+        rx.recv().unwrap();
         Ok(())
     }
 

--- a/light-client-bin/src/rpc.rs
+++ b/light-client-bin/src/rpc.rs
@@ -140,8 +140,7 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
         std::thread::spawn(move || {
             let mut matched_blocks = swc.matched_blocks().blocking_write();
             let scripts = scripts.into_iter().map(Into::into).collect();
-            swc
-                .storage()
+            swc.storage()
                 .update_filter_scripts(scripts, command.map(Into::into).unwrap_or_default());
             matched_blocks.clear();
             tx.send(()).unwrap();

--- a/light-client-bin/src/tests/service.rs
+++ b/light-client-bin/src/tests/service.rs
@@ -1373,7 +1373,7 @@ fn test_set_scripts_clear_matched_blocks() {
     storage.add_matched_blocks(2233, 200, vec![(H256(rand::random()).pack(), false)]);
     storage.add_matched_blocks(4455, 200, vec![(H256(rand::random()).pack(), false)]);
     {
-        let mut matched_blocks = peers.matched_blocks().write().unwrap();
+        let mut matched_blocks = peers.matched_blocks().blocking_write();
         peers.add_matched_blocks(
             &mut matched_blocks,
             vec![(H256(rand::random()).pack(), false)],
@@ -1409,7 +1409,7 @@ fn test_set_scripts_clear_matched_blocks() {
     );
     assert!(storage.get_earliest_matched_blocks().is_none());
     assert!(storage.get_latest_matched_blocks().is_none());
-    assert!(peers.matched_blocks().read().unwrap().is_empty());
+    assert!(peers.matched_blocks().blocking_read().is_empty());
 }
 
 #[test]

--- a/light-client-lib/Cargo.toml
+++ b/light-client-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client-lib"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -163,7 +163,7 @@ impl FilterProtocol {
             .max_by_key(|(_, prove_state)| prove_state.get_last_header().total_difficulty())
         {
             debug!("found best proved peer {}", peer);
-            
+
             let mut matched_blocks = self.peers.matched_blocks().write().await;
             if let Some((db_start_number, blocks_count, db_blocks)) =
                 self.storage.get_earliest_matched_blocks()

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -163,12 +163,11 @@ impl FilterProtocol {
             .max_by_key(|(_, prove_state)| prove_state.get_last_header().total_difficulty())
         {
             debug!("found best proved peer {}", peer);
-
+            
+            let mut matched_blocks = self.peers.matched_blocks().write().await;
             if let Some((db_start_number, blocks_count, db_blocks)) =
                 self.storage.get_earliest_matched_blocks()
             {
-                let mut matched_blocks = self.peers.matched_blocks().write().await;
-
                 debug!(
                     "try recover matched blocks from storage, start_number={}, \
                              blocks_count={}, matched_count: {}",

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -167,11 +167,7 @@ impl FilterProtocol {
             if let Some((db_start_number, blocks_count, db_blocks)) =
                 self.storage.get_earliest_matched_blocks()
             {
-                #[cfg(target_arch = "wasm32")]
                 let mut matched_blocks = self.peers.matched_blocks().write().await;
-
-                #[cfg(not(target_arch = "wasm32"))]
-                let mut matched_blocks = self.peers.matched_blocks().write().expect("poisoned");
 
                 debug!(
                     "try recover matched blocks from storage, start_number={}, \

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -260,14 +260,14 @@ impl<'a> BlockFiltersProcess<'a> {
                     .storage
                     .update_block_number(filtered_block_number)
             }
+            #[cfg(target_arch = "wasm32")]
+            self.filter
+                .update_min_filtered_block_number(filtered_block_number)
+                .await;
+            #[cfg(not(target_arch = "wasm32"))]
+            self.filter
+                .update_min_filtered_block_number(filtered_block_number);
         }
-        #[cfg(target_arch = "wasm32")]
-        self.filter
-            .update_min_filtered_block_number(filtered_block_number)
-            .await;
-        #[cfg(not(target_arch = "wasm32"))]
-        self.filter
-            .update_min_filtered_block_number(filtered_block_number);
 
         let could_request_more_block_filters = self
             .filter

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -260,6 +260,7 @@ impl<'a> BlockFiltersProcess<'a> {
                     .storage
                     .update_block_number(filtered_block_number)
             }
+            // Lock of `matched_blocks` must be held over `update_min_filtered_block_number`
             #[cfg(target_arch = "wasm32")]
             self.filter
                 .update_min_filtered_block_number(filtered_block_number)

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -53,6 +53,7 @@ impl<'a> BlockFiltersProcess<'a> {
             warn!("ignoring, peer {} prove state is none", self.peer);
             return Status::ok();
         };
+        let mut matched_blocks = self.filter.peers.matched_blocks().write().await;
 
         let block_filters = self.message.to_entity();
         let start_number: BlockNumber = block_filters.start_number().unpack();
@@ -216,7 +217,6 @@ impl<'a> BlockFiltersProcess<'a> {
         let actual_blocks_count = blocks_count.min(limit);
         let tip_header = self.filter.storage.get_tip_header();
         let filtered_block_number = start_number - 1 + actual_blocks_count as BlockNumber;
-        let mut matched_blocks = self.filter.peers.matched_blocks().write().await;
 
         if possible_match_blocks_len != 0 {
             let blocks = possible_match_blocks
@@ -250,7 +250,6 @@ impl<'a> BlockFiltersProcess<'a> {
                 .storage
                 .update_block_number(filtered_block_number)
         }
-        // Lock of `matched_blocks` must be held over `update_min_filtered_block_number`
         #[cfg(target_arch = "wasm32")]
         self.filter
             .update_min_filtered_block_number(filtered_block_number)

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -216,59 +216,48 @@ impl<'a> BlockFiltersProcess<'a> {
         let actual_blocks_count = blocks_count.min(limit);
         let tip_header = self.filter.storage.get_tip_header();
         let filtered_block_number = start_number - 1 + actual_blocks_count as BlockNumber;
-        // Use these braces to avoid holding `matched_blocks` across `.await`
-        {
-            #[cfg(target_arch = "wasm32")]
-            let mut matched_blocks = self.filter.peers.matched_blocks().write().await;
+        let mut matched_blocks = self.filter.peers.matched_blocks().write().await;
 
-            #[cfg(not(target_arch = "wasm32"))]
-            let mut matched_blocks = self
-                .filter
-                .peers
-                .matched_blocks()
-                .write()
-                .expect("poisoned");
-            if possible_match_blocks_len != 0 {
-                let blocks = possible_match_blocks
-                    .iter()
-                    .map(|block_hash| (block_hash.clone(), block_hash == &prove_state_block_hash))
-                    .collect::<Vec<_>>();
-                self.filter.storage.add_matched_blocks(
-                    start_number,
-                    actual_blocks_count as u64,
-                    blocks,
-                );
-                let option = matched_blocks.is_empty();
-                if option {
-                    if let Some((_start_number, _blocks_count, db_blocks)) =
-                        self.filter.storage.get_earliest_matched_blocks()
-                    {
-                        self.filter
-                            .peers
-                            .add_matched_blocks(&mut matched_blocks, db_blocks);
-                        prove_or_download_matched_blocks(
-                            Arc::clone(&self.filter.peers),
-                            &tip_header,
-                            &matched_blocks,
-                            self.nc.as_ref(),
-                            INIT_BLOCKS_IN_TRANSIT_PER_PEER,
-                        );
-                    }
+        if possible_match_blocks_len != 0 {
+            let blocks = possible_match_blocks
+                .iter()
+                .map(|block_hash| (block_hash.clone(), block_hash == &prove_state_block_hash))
+                .collect::<Vec<_>>();
+            self.filter.storage.add_matched_blocks(
+                start_number,
+                actual_blocks_count as u64,
+                blocks,
+            );
+            let option = matched_blocks.is_empty();
+            if option {
+                if let Some((_start_number, _blocks_count, db_blocks)) =
+                    self.filter.storage.get_earliest_matched_blocks()
+                {
+                    self.filter
+                        .peers
+                        .add_matched_blocks(&mut matched_blocks, db_blocks);
+                    prove_or_download_matched_blocks(
+                        Arc::clone(&self.filter.peers),
+                        &tip_header,
+                        &matched_blocks,
+                        self.nc.as_ref(),
+                        INIT_BLOCKS_IN_TRANSIT_PER_PEER,
+                    );
                 }
-            } else if matched_blocks.is_empty() {
-                self.filter
-                    .storage
-                    .update_block_number(filtered_block_number)
             }
-            // Lock of `matched_blocks` must be held over `update_min_filtered_block_number`
-            #[cfg(target_arch = "wasm32")]
+        } else if matched_blocks.is_empty() {
             self.filter
-                .update_min_filtered_block_number(filtered_block_number)
-                .await;
-            #[cfg(not(target_arch = "wasm32"))]
-            self.filter
-                .update_min_filtered_block_number(filtered_block_number);
+                .storage
+                .update_block_number(filtered_block_number)
         }
+        // Lock of `matched_blocks` must be held over `update_min_filtered_block_number`
+        #[cfg(target_arch = "wasm32")]
+        self.filter
+            .update_min_filtered_block_number(filtered_block_number)
+            .await;
+        #[cfg(not(target_arch = "wasm32"))]
+        self.filter
+            .update_min_filtered_block_number(filtered_block_number);
 
         let could_request_more_block_filters = self
             .filter

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -152,15 +152,8 @@ impl<'a> SendBlocksProofProcess<'a> {
                 let block_hashes: Vec<packed::Byte32> =
                     headers.iter().map(|header| header.hash()).collect();
                 {
-                    #[cfg(target_arch = "wasm32")]
                     let mut matched_blocks = self.protocol.peers().matched_blocks().write().await;
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let mut matched_blocks = self
-                        .protocol
-                        .peers()
-                        .matched_blocks()
-                        .write()
-                        .expect("poisoned");
+
                     self.protocol
                         .peers
                         .mark_matched_blocks_proved(&mut matched_blocks, &block_hashes);

--- a/light-client-lib/src/protocols/light_client/mod.rs
+++ b/light-client-lib/src/protocols/light_client/mod.rs
@@ -353,6 +353,7 @@ impl LightClientProtocol {
                 // For safety, just remove the block#1.
                 if prev_last_header_number == 1 {
                     info!("rollback to block#1 since previous last header number is 1");
+                    let mut matched_blocks = self.peers.matched_blocks().write().await;
 
                     while let Some((start_number, _, _)) = self.storage.get_latest_matched_blocks()
                     {
@@ -361,7 +362,6 @@ impl LightClientProtocol {
                         }
                     }
                     self.storage.rollback_to_block(1);
-                    let mut matched_blocks = self.peers.matched_blocks().write().await;
 
                     matched_blocks.clear();
                 }
@@ -383,6 +383,7 @@ impl LightClientProtocol {
                 });
                 if let Some(to_number) = fork_number {
                     debug!("fork to number: {}", to_number);
+                    let mut matched_blocks = self.peers.matched_blocks().write().await;
                     let mut start_number_opt = None;
                     while let Some((start_number, _, _)) = self.storage.get_latest_matched_blocks()
                     {
@@ -397,7 +398,6 @@ impl LightClientProtocol {
                     let rollback_to = start_number_opt.unwrap_or(to_number) + 1;
                     info!("rollback to block#{}", rollback_to);
                     self.storage.rollback_to_block(rollback_to);
-                    let mut matched_blocks = self.peers.matched_blocks().write().await;
                     matched_blocks.clear();
                 } else {
                     warn!("long fork detected");

--- a/light-client-lib/src/protocols/light_client/mod.rs
+++ b/light-client-lib/src/protocols/light_client/mod.rs
@@ -361,10 +361,7 @@ impl LightClientProtocol {
                         }
                     }
                     self.storage.rollback_to_block(1);
-                    #[cfg(target_arch = "wasm32")]
                     let mut matched_blocks = self.peers.matched_blocks().write().await;
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let mut matched_blocks = self.peers.matched_blocks().write().expect("poisoned");
 
                     matched_blocks.clear();
                 }
@@ -400,10 +397,7 @@ impl LightClientProtocol {
                     let rollback_to = start_number_opt.unwrap_or(to_number) + 1;
                     info!("rollback to block#{}", rollback_to);
                     self.storage.rollback_to_block(rollback_to);
-                    #[cfg(target_arch = "wasm32")]
                     let mut matched_blocks = self.peers.matched_blocks().write().await;
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let mut matched_blocks = self.peers.matched_blocks().write().expect("poisoned");
                     matched_blocks.clear();
                 } else {
                     warn!("long fork detected");
@@ -706,10 +700,7 @@ impl LightClientProtocol {
 
     async fn get_idle_blocks(&mut self, nc: &BoxedCKBProtocolContext) {
         let tip_header = self.storage.get_tip_header();
-        #[cfg(target_arch = "wasm32")]
         let matched_blocks = self.peers.matched_blocks().read().await;
-        #[cfg(not(target_arch = "wasm32"))]
-        let matched_blocks = self.peers.matched_blocks().read().expect("poisoned");
 
         prove_or_download_matched_blocks(
             Arc::clone(&self.peers),

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -35,7 +35,7 @@ pub struct Peers {
     // The matched block filters to download, the key is the block hash, the value is:
     //   * if the block is proved
     //   * the downloaded block
-    matched_blocks: RwLock<HashMap<H256, (bool, Option<packed::Block>)>>,
+    matched_blocks: tokio::sync::RwLock<HashMap<H256, (bool, Option<packed::Block>)>>,
 
     // Data:
     // - Cached check point index.
@@ -1269,7 +1269,9 @@ impl Peers {
         }
     }
 
-    pub fn matched_blocks(&self) -> &RwLock<HashMap<H256, (bool, Option<packed::Block>)>> {
+    pub fn matched_blocks(
+        &self,
+    ) -> &tokio::sync::RwLock<HashMap<H256, (bool, Option<packed::Block>)>> {
         &self.matched_blocks
     }
 

--- a/light-client-lib/src/protocols/synchronizer.rs
+++ b/light-client-lib/src/protocols/synchronizer.rs
@@ -60,10 +60,7 @@ impl CKBProtocolHandler for SyncProtocol {
         match message {
             packed::SyncMessageUnionReader::SendBlock(reader) => {
                 let new_block = reader.to_entity().block();
-                #[cfg(target_arch = "wasm32")]
                 let mut matched_blocks = self.peers.matched_blocks().write().await;
-                #[cfg(not(target_arch = "wasm32"))]
-                let mut matched_blocks = self.peers.matched_blocks().write().expect("poisoned");
                 self.peers.add_block(&mut matched_blocks, new_block);
                 if !matched_blocks.is_empty()
                     && self.peers.all_matched_blocks_downloaded(&matched_blocks)

--- a/light-client-lib/src/storage/mod.rs
+++ b/light-client-lib/src/storage/mod.rs
@@ -131,7 +131,9 @@ impl StorageWithChainData {
         &self.pending_txs
     }
 
-    pub fn matched_blocks(&self) -> &RwLock<HashMap<H256, (bool, Option<packed::Block>)>> {
+    pub fn matched_blocks(
+        &self,
+    ) -> &tokio::sync::RwLock<HashMap<H256, (bool, Option<packed::Block>)>> {
         self.peers.matched_blocks()
     }
     /// return (added_ts, first_sent, missing)

--- a/light-client-lib/src/tests/protocols/light_client/mod.rs
+++ b/light-client-lib/src/tests/protocols/light_client/mod.rs
@@ -197,7 +197,7 @@ async fn test_light_client_get_idle_matched_blocks() {
         (proved_block_hash.clone(), true),
     ];
     {
-        let mut matched_blocks = peers.matched_blocks().write().expect("poisoned");
+        let mut matched_blocks = peers.matched_blocks().write().await;
         peers.add_matched_blocks(&mut matched_blocks, blocks);
     }
 

--- a/light-client-lib/src/tests/protocols/light_client/send_last_state_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_last_state_proof.rs
@@ -1709,7 +1709,7 @@ async fn test_with_reorg_blocks(param: ReorgTestParameter) {
         peers
             .matched_blocks()
             .write()
-            .unwrap()
+            .await
             .insert(downloading_matched_block.clone(), (false, None));
         peers
     };
@@ -2014,7 +2014,7 @@ async fn test_with_reorg_blocks(param: ReorgTestParameter) {
             );
         }
         assert_eq!(
-            peers.matched_blocks().read().unwrap().is_empty(),
+            peers.matched_blocks().read().await.is_empty(),
             last_number > prev_last_number
         );
     }

--- a/light-client-lib/src/tests/protocols/synchronizer.rs
+++ b/light-client-lib/src/tests/protocols/synchronizer.rs
@@ -50,7 +50,7 @@ async fn test_sync_add_block() {
         let peers = chain.create_peers();
         peers.add_peer(peer_index);
         {
-            let mut matched_blocks = peers.matched_blocks().write().unwrap();
+            let mut matched_blocks = peers.matched_blocks().write().await;
             peers.add_matched_blocks(&mut matched_blocks, vec![(proved_block_hash, true)]);
         }
         peers
@@ -69,7 +69,7 @@ async fn test_sync_add_block() {
     let mut protocol = chain.create_sync_protocol(Arc::clone(&peers));
     protocol.received(nc.context(), peer_index, message).await;
 
-    assert!(peers.matched_blocks().read().unwrap().is_empty());
+    assert!(peers.matched_blocks().read().await.is_empty());
     assert!(chain
         .client_storage()
         .get_earliest_matched_blocks()

--- a/wasm/light-client-js/package.json
+++ b/wasm/light-client-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-light-client-js",
   "repository": "https://github.com/nervosnetwork/ckb-light-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Lock of https://github.com/nervosnetwork/ckb-light-client/blob/2b879cd0503884ea1c47bd31d72da41a38d2f8ab/light-client-lib/src/protocols/filter/components/block_filters_process.rs#L222 should be held until the `execute` functions returns. This PR changes the lock to `tokio::sync::RwLock` and modified the scope of the lock. Changing to `tokio::sync::RwLock` is to avoid holding `std::sync::RwLockGuard` over `.await` points