### PR TITLE
light-client-wasm: support using JS object as configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "serde_json",
  "tentacle-multiaddr",
  "tentacle-secio",
- "toml",
+ "toml 0.5.11",
  "ubyte",
  "url",
 ]
@@ -521,7 +521,7 @@ dependencies = [
  "ckb-traits",
  "ckb-types",
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
@@ -2798,6 +2798,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "tokio",
+ "toml 0.8.23",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",
@@ -3354,7 +3355,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3843,6 +3844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,6 +4303,47 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower-service"
@@ -4880,6 +4931,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/wasm/light-client-js/src/index.ts
+++ b/wasm/light-client-js/src/index.ts
@@ -52,8 +52,14 @@ class LightClient {
      * @param networkSecretKey A secret key used to derive keys during data transport between nodes. This key should be persistent for a unique client.
      * @param logLevel Log Level for light-client-db-worker and light-client-wasm
      * @param transportType Specify transport type. `ws` stands for non-secure WebSocket, while `wss` stands for WebSocket over SSL.
+     * @param networkConfigIsJSObject Sets to true if `NetworkSetting.config` is provided as a JS object, otherwise it should be a TOML string.
      */
-    async start(networkSetting: NetworkSetting, networkSecretKey: Hex, logLevel: "trace" | "debug" | "info" | "error" = "info", transportType: "ws" | "wss" = "ws") {
+    async start(
+        networkSetting: NetworkSetting,
+        networkSecretKey: Hex,
+        logLevel: "trace" | "debug" | "info" | "error" = "info", transportType: "ws" | "wss" = "ws",
+        networkConfigIsJSObject: boolean = false,
+    ) {
         this.dbWorker.postMessage({
             inputBuffer: this.inputBuffer,
             outputBuffer: this.outputBuffer,
@@ -66,7 +72,8 @@ class LightClient {
             logLevel: logLevel,
             traceLogBuffer: this.traceLogBuffer,
             networkSecretKey: bytesFrom(networkSecretKey),
-            transportType
+            transportType,
+            networkConfigIsJSObject
         } as LightClientWorkerInitializeOptions);
         await new Promise<void>((res, rej) => {
             this.dbWorker.onmessage = () => res();

--- a/wasm/light-client-js/src/lightclient.worker.ts
+++ b/wasm/light-client-js/src/lightclient.worker.ts
@@ -8,7 +8,16 @@ onmessage = async (evt) => {
     if (!loaded) {
         const data = evt.data as LightClientWorkerInitializeOptions;
         wasmModule.set_shared_array(data.inputBuffer, data.outputBuffer);
-        await wasmModule.light_client(data.networkFlag, data.logLevel, data.networkSecretKey, data.transportType);
+        if (data.networkConfigIsJSObject) {
+            data.networkFlag.config = JSON.stringify(data.networkFlag.config);
+        }
+        await wasmModule.light_client(
+            data.networkFlag,
+            data.logLevel,
+            data.networkSecretKey,
+            data.transportType,
+            data.networkConfigIsJSObject,
+        );
         self.postMessage({});
         loaded = true;
         return;

--- a/wasm/light-client-js/src/types.ts
+++ b/wasm/light-client-js/src/types.ts
@@ -21,7 +21,8 @@ interface DbWorkerInitializeOptions extends WorkerInitializeOptions {
 
 interface LightClientWorkerInitializeOptions extends WorkerInitializeOptions {
     networkFlag: NetworkSetting;
-    networkSecretKey: Uint8Array
+    networkSecretKey: Uint8Array;
+    networkConfigIsJSObject: boolean;
 };
 
 interface LightClientFunctionCall {
@@ -178,7 +179,9 @@ export function localNodeTo(input: LightClientLocalNode): LocalNode {
         version: input.version
     })
 }
-type NetworkSetting = { type: "MainNet"; config?: string; } | { type: "TestNet"; config?: string; } | { type: "DevNet"; spec: string; config: string; };
+type NetworkSetting = { type: "MainNet"; config?: string | any; } |
+{ type: "TestNet"; config?: string | any; } |
+{ type: "DevNet"; spec: string; config: string | any; };
 export enum LightClientSetScriptsCommand {
     All = 0,
     Partial = 1,

--- a/wasm/light-client-wasm/Cargo.toml
+++ b/wasm/light-client-wasm/Cargo.toml
@@ -35,6 +35,7 @@ ckb-app-config = "0.202.0"
 
 getrandom = { version = "0.2", features = ["js"] }
 tokio = { version = "1.20" }
+toml = "0.8.23"
 
 [features]
 default = ["console_error_panic_hook"]

--- a/wasm/light-client-wasm/src/lib.rs
+++ b/wasm/light-client-wasm/src/lib.rs
@@ -93,6 +93,7 @@ pub async fn light_client(
     log_level: String,
     network_secret_key: JsValue,
     wasm_transport_type: JsValue,
+    network_config_is_json: bool,
 ) -> Result<(), JsValue> {
     if !status(0b0) {
         return Err(JsValue::from_str("Can't start twice"));
@@ -109,20 +110,35 @@ pub async fn light_client(
         "Starting with wasm transport type = {:?}",
         wasm_transport_type
     );
-    let mut config = match &network_flag {
+    enum NetworkConfigType<'a> {
+        Default(&'a str),
+        UserDefined(&'a str),
+    }
+    let config_string = match &network_flag {
         NetworkSetting::TestNet { config } => config
             .as_ref()
-            .map_or(TESTNET_CONFIG, |v| v)
-            .parse::<RunEnv>()
-            .unwrap(),
+            .map_or(NetworkConfigType::Default(TESTNET_CONFIG), |v| {
+                NetworkConfigType::UserDefined(v.as_str())
+            }),
         NetworkSetting::MainNet { config } => config
             .as_ref()
-            .map_or(MAINNET_CONFIG, |v| v)
-            .parse::<RunEnv>()
-            .unwrap(),
-        NetworkSetting::DevNet { config, .. } => config.parse::<RunEnv>().unwrap(),
+            .map_or(NetworkConfigType::Default(MAINNET_CONFIG), |v| {
+                NetworkConfigType::UserDefined(v.as_str())
+            }),
+        NetworkSetting::DevNet { config, .. } => NetworkConfigType::UserDefined(config.as_str()),
     };
-
+    let mut config = match config_string {
+        NetworkConfigType::Default(s) => s.parse::<RunEnv>().unwrap(),
+        NetworkConfigType::UserDefined(s) => {
+            if network_config_is_json {
+                serde_json::from_str(s)
+                    .map_err(|e| format!("Unable to parse network setting from json: {}", e))?
+            } else {
+                s.parse::<RunEnv>()
+                    .map_err(|e| format!("Unable to parse network setting from toml: {}", e))?
+            }
+        }
+    };
     let storage = Storage::new(&config.store.path);
     let chain_spec = ChainSpec::load_from(&match network_flag {
         NetworkSetting::MainNet { .. } => Resource::bundled("specs/mainnet.toml".to_string()),


### PR DESCRIPTION
Closes #220 

This PR supports using JS object as network config when starting a light client wasm instance, for example:
```js
const networkConfig = {
    "chain": "testnet",
    "store": {
        "path": "data/store"
    },
    "network": {
        "path": "data/network",
        "listen_addresses": [
            "/ip4/0.0.0.0/tcp/8110"
        ],
        "bootnodes": [
            "/dns4/dagon.ckb.guide/tcp/443/wss/p2p/QmX5D6aJiAQ5Fxn4BfVqSn6zrgyuQM1oXVC9yvmzLuHXnx",
            "/dns4/javelin.ckb.guide/tcp/443/wss/p2p/QmPcJY2gZLUm66szYA9QaG1P3rzwseWCMgbj6AyNCyW4G2",
            "/dns4/diadem.ckb.guide/tcp/443/wss/p2p/QmQMjFrNGaphzfHin3mbYybbJcFMDUihKAcknquYvm9J3W",
            "/dns4/bloodstone.ckb.guide/tcp/443/wss/p2p/QmQoTR39rBkpZVgLApDGDoFnJ2YDBS9hYeiib1Z6aoAdEf",
            "/dns4/crown.ckb.guide/tcp/443/wss/p2p/QmTt6HeNakL8Fpmevrhdna7J4NzEMf9pLchf1CXtmtSrwb",
            "/dns4/mekansm.ckb.guide/tcp/443/wss/p2p/QmT6DFfm18wtbJz3y4aPNn3ac86N4d4p4xtfQRRPf73frC",
            "/dns4/circlet.ckb.guide/tcp/443/wss/p2p/Qmd41MaByDprkC5gP1XBKgamZ9DTLNk37zbPgwtiWCzRV6",
            "/dns4/vanguard.ckb.guide/tcp/443/wss/p2p/QmWVuW5KquiWDSqgMJRFW1xRtVqkYJrWz6S9NNk6fFn3wh",
            "/dns4/chainmail.ckb.guide/tcp/443/wss/p2p/QmfUTZxsse7rFJTJfoUv8bbStoDLETxst5nJEpJozNuAnH",
            "/dns4/gleipnir.ckb.guide/tcp/443/wss/p2p/QmSPkAyXqsWpRiS7HpHLTProVdhQWLKFHCXbRjaLpJj7ZL",
            "/dns4/parasma.ckb.guide/tcp/443/wss/p2p/QmSJTsMsMGBjzv1oBNwQU36VhQRxc2WQpFoRu1ZifYKrjZ",
            "/dns4/bottle.ckb.guide/tcp/443/wss/p2p/QmWcEhsMNRcfJit62EbKgzpgtAJZX1G3Ur4shXjcvLsYDb"
        ],
        "max_peers": 125,
        "max_outbound_peers": 2,
        "ping_interval_secs": 120,
        "ping_timeout_secs": 1200,
        "connect_outbound_interval_secs": 15,
        "upnp": false,
        "discovery_local_address": false,
        "bootnode_mode": false
    },
    "rpc": {
        "listen_address": "127.0.0.1:9000"
    }
}
await client.start({ type: "TestNet", config: networkConfig }, secretKey, enableDebug ? "debug" : "info", "ws", true);              
```

As described in function comments, the last argument of `LightClient.start` is used to indicate whether the network config is in JS object or TOML string.