### PR TITLE
light-client-wasm: provide basic database API for JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "ckb-types",
  "console_error_panic_hook",
  "getrandom 0.2.15",
+ "light-client-db-common",
  "log",
  "serde",
  "serde-wasm-bindgen",

--- a/light-client-lib/src/storage/db/browser.rs
+++ b/light-client-lib/src/storage/db/browser.rs
@@ -26,7 +26,7 @@ use ckb_types::{
 pub use idb::CursorDirection;
 use light_client_db_common::{
     idb_cursor_direction_to_ckb, read_command_payload, write_command_with_payload,
-    DbCommandRequest, DbCommandResponse, InputCommand, OutputCommand, KV,
+    DbCommandRequest, DbCommandResponse, GetRecordCountType, InputCommand, OutputCommand, KV,
 };
 
 use log::debug;
@@ -68,7 +68,9 @@ enum CommandRequestWithTakeWhile {
         limit: usize,
         skip: usize,
     },
-    GetRecordCount,
+    GetRecordCount {
+        prefix: Vec<u8>,
+    },
 }
 
 thread_local! {
@@ -195,7 +197,9 @@ impl CommunicationChannel {
                 },
                 Some(take_while),
             ),
-            CommandRequestWithTakeWhile::GetRecordCount => (DbCommandRequest::GetRecordCount, None),
+            CommandRequestWithTakeWhile::GetRecordCount { prefix } => {
+                (DbCommandRequest::GetRecordCount { prefix }, None)
+            }
         };
         debug!("Dispatching database command: {:?}", new_cmd);
         let CommunicationChannel {
@@ -286,10 +290,22 @@ impl Storage {
         Self { channel: chan }
     }
 
-    pub fn get_store_record_count(&self) -> usize {
+    pub fn get_store_record_count(&self, record_type: GetRecordCountType) -> usize {
+        let prefix = match record_type {
+            GetRecordCountType::All => vec![],
+            GetRecordCountType::Transaction => vec![KeyPrefix::TxHash as u8],
+            GetRecordCountType::CellLockScript => vec![KeyPrefix::CellLockScript as u8],
+            GetRecordCountType::CellTypeScript => vec![KeyPrefix::CellTypeScript as u8],
+            GetRecordCountType::TxLockScript => vec![KeyPrefix::TxLockScript as u8],
+            GetRecordCountType::TxTypeScript => vec![KeyPrefix::TxTypeScript as u8],
+            GetRecordCountType::BlockByHash => vec![KeyPrefix::BlockHash as u8],
+            GetRecordCountType::BlockByNumber => vec![KeyPrefix::BlockNumber as u8],
+            GetRecordCountType::CheckPointIndex => vec![KeyPrefix::CheckPointIndex as u8],
+            GetRecordCountType::Meta => vec![KeyPrefix::Meta as u8],
+        };
         let result = self
             .channel
-            .dispatch_database_command(CommandRequestWithTakeWhile::GetRecordCount)
+            .dispatch_database_command(CommandRequestWithTakeWhile::GetRecordCount { prefix })
             .map_err(|e| Error::Indexdb(format!("{:?}", e)))
             .unwrap();
         match result {

--- a/light-client-lib/src/storage/db/browser.rs
+++ b/light-client-lib/src/storage/db/browser.rs
@@ -68,6 +68,7 @@ enum CommandRequestWithTakeWhile {
         limit: usize,
         skip: usize,
     },
+    GetRecordCount,
 }
 
 thread_local! {
@@ -194,6 +195,7 @@ impl CommunicationChannel {
                 },
                 Some(take_while),
             ),
+            CommandRequestWithTakeWhile::GetRecordCount => (DbCommandRequest::GetRecordCount, None),
         };
         debug!("Dispatching database command: {:?}", new_cmd);
         let CommunicationChannel {
@@ -282,6 +284,18 @@ impl Storage {
             DB_INITIALIZED.store(true, std::sync::atomic::Ordering::SeqCst);
         }
         Self { channel: chan }
+    }
+
+    pub fn get_store_record_count(&self) -> usize {
+        let result = self
+            .channel
+            .dispatch_database_command(CommandRequestWithTakeWhile::GetRecordCount)
+            .map_err(|e| Error::Indexdb(format!("{:?}", e)))
+            .unwrap();
+        match result {
+            DbCommandResponse::GetRecordCount { count } => count,
+            _ => unreachable!(),
+        }
     }
 
     fn batch(&self) -> Batch {

--- a/wasm/light-client-db-common/src/lib.rs
+++ b/wasm/light-client-db-common/src/lib.rs
@@ -38,21 +38,15 @@ pub enum DbCommandRequest {
     /// Read the value corresponding to a series of keys
     /// Input: A series of keys
     /// Output: A series of values corresponding to keys, None if the key wasn't found in database
-    Read {
-        keys: Vec<Vec<u8>>,
-    },
+    Read { keys: Vec<Vec<u8>> },
     /// Write a series of key-value pairs into database
     /// Input: A series of key-value pairs
     /// Output: None
-    Put {
-        kvs: Vec<KV>,
-    },
+    Put { kvs: Vec<KV> },
     /// Remove a series of entries from database
     /// Input: Keys to remove
     /// Output: None
-    Delete {
-        keys: Vec<Vec<u8>>,
-    },
+    Delete { keys: Vec<Vec<u8>> },
     /// Gets at most `limit` entries, starting from `start_key_bound`, skipping the first `skip` entries, keep fetching until `take_while` evals to false
     /// Output: Key value pairs fetched
     Iterator {
@@ -68,8 +62,24 @@ pub enum DbCommandRequest {
         limit: usize,
         skip: usize,
     },
-    GetRecordCount,
+    /// Count how many records statisfies the specified prefix
+    GetRecordCount { prefix: Vec<u8> },
 }
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum GetRecordCountType {
+    All,
+    Transaction,
+    CellLockScript,
+    CellTypeScript,
+    TxLockScript,
+    TxTypeScript,
+    BlockByHash,
+    BlockByNumber,
+    CheckPointIndex,
+    Meta,
+}
+
 #[repr(i32)]
 /// Represent a 4-byte command which will be put in input buffer
 pub enum InputCommand {

--- a/wasm/light-client-db-common/src/lib.rs
+++ b/wasm/light-client-db-common/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DbCommandResponse {
     Delete,
     Iterator { kvs: Vec<KV> },
     IteratorKey { keys: Vec<Vec<u8>> },
+    GetRecordCount { count: usize },
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -37,15 +38,21 @@ pub enum DbCommandRequest {
     /// Read the value corresponding to a series of keys
     /// Input: A series of keys
     /// Output: A series of values corresponding to keys, None if the key wasn't found in database
-    Read { keys: Vec<Vec<u8>> },
+    Read {
+        keys: Vec<Vec<u8>>,
+    },
     /// Write a series of key-value pairs into database
     /// Input: A series of key-value pairs
     /// Output: None
-    Put { kvs: Vec<KV> },
+    Put {
+        kvs: Vec<KV>,
+    },
     /// Remove a series of entries from database
     /// Input: Keys to remove
     /// Output: None
-    Delete { keys: Vec<Vec<u8>> },
+    Delete {
+        keys: Vec<Vec<u8>>,
+    },
     /// Gets at most `limit` entries, starting from `start_key_bound`, skipping the first `skip` entries, keep fetching until `take_while` evals to false
     /// Output: Key value pairs fetched
     Iterator {
@@ -61,6 +68,7 @@ pub enum DbCommandRequest {
         limit: usize,
         skip: usize,
     },
+    GetRecordCount,
 }
 #[repr(i32)]
 /// Represent a 4-byte command which will be put in input buffer

--- a/wasm/light-client-db-worker/src/db.rs
+++ b/wasm/light-client-db-worker/src/db.rs
@@ -187,9 +187,9 @@ where
 {
     debug!("Handle command: {:?}", cmd);
     let tx_mode = match cmd {
-        DbCommandRequest::Iterator { .. } | DbCommandRequest::IteratorKey { .. } => {
-            TransactionMode::ReadOnly
-        }
+        DbCommandRequest::Iterator { .. }
+        | DbCommandRequest::IteratorKey { .. }
+        | DbCommandRequest::GetRecordCount => TransactionMode::ReadOnly,
         DbCommandRequest::Read { .. } => TransactionMode::ReadOnly,
         DbCommandRequest::Put { .. } | DbCommandRequest::Delete { .. } => {
             TransactionMode::ReadWrite
@@ -204,6 +204,17 @@ where
         .map_err(|e| anyhow!("Unable to find store {}: {}", store_name, e))?;
 
     let result = match cmd {
+        DbCommandRequest::GetRecordCount => {
+            let count = store
+                .count(None)
+                .map_err(|e| anyhow!("Unable to create query store size request: {}", e))?
+                .await
+                .map_err(|e| anyhow!("Unable to get store size: {}", e))?;
+
+            DbCommandResponse::GetRecordCount {
+                count: count as usize,
+            }
+        }
         DbCommandRequest::Read { keys } => {
             let mut res = Vec::new();
             for key in keys {

--- a/wasm/light-client-db-worker/src/db.rs
+++ b/wasm/light-client-db-worker/src/db.rs
@@ -189,7 +189,7 @@ where
     let tx_mode = match cmd {
         DbCommandRequest::Iterator { .. }
         | DbCommandRequest::IteratorKey { .. }
-        | DbCommandRequest::GetRecordCount => TransactionMode::ReadOnly,
+        | DbCommandRequest::GetRecordCount { .. } => TransactionMode::ReadOnly,
         DbCommandRequest::Read { .. } => TransactionMode::ReadOnly,
         DbCommandRequest::Put { .. } | DbCommandRequest::Delete { .. } => {
             TransactionMode::ReadWrite
@@ -204,9 +204,20 @@ where
         .map_err(|e| anyhow!("Unable to find store {}: {}", store_name, e))?;
 
     let result = match cmd {
-        DbCommandRequest::GetRecordCount => {
+        DbCommandRequest::GetRecordCount { prefix } => {
+            let lower_bound = serde_wasm_bindgen::to_value(&prefix).unwrap();
+            let upper_bound = {
+                let mut upper_bound = prefix.clone();
+                upper_bound.push(255);
+                serde_wasm_bindgen::to_value(&upper_bound).unwrap()
+            };
             let count = store
-                .count(None)
+                .count(Some(idb::Query::KeyRange(KeyRange::bound(
+                    &lower_bound,
+                    &upper_bound,
+                    Some(false),
+                    Some(false),
+                ).unwrap())))
                 .map_err(|e| anyhow!("Unable to create query store size request: {}", e))?
                 .await
                 .map_err(|e| anyhow!("Unable to get store size: {}", e))?;

--- a/wasm/light-client-db-worker/src/db.rs
+++ b/wasm/light-client-db-worker/src/db.rs
@@ -212,12 +212,9 @@ where
                 serde_wasm_bindgen::to_value(&upper_bound).unwrap()
             };
             let count = store
-                .count(Some(idb::Query::KeyRange(KeyRange::bound(
-                    &lower_bound,
-                    &upper_bound,
-                    Some(false),
-                    Some(false),
-                ).unwrap())))
+                .count(Some(idb::Query::KeyRange(
+                    KeyRange::bound(&lower_bound, &upper_bound, Some(false), Some(false)).unwrap(),
+                )))
                 .map_err(|e| anyhow!("Unable to create query store size request: {}", e))?
                 .await
                 .map_err(|e| anyhow!("Unable to get store size: {}", e))?;

--- a/wasm/light-client-js/src/index.ts
+++ b/wasm/light-client-js/src/index.ts
@@ -1,5 +1,5 @@
 import { ClientIndexerSearchKeyLike, ClientIndexerSearchKeyTransactionLike, ClientTransactionResponse } from "@ckb-ccc/core";
-import { FetchResponse, LocalNode, localNodeTo, RemoteNode, remoteNodeTo, ScriptStatus, scriptStatusFrom, scriptStatusTo, LightClientSetScriptsCommand, transformFetchResponse, cccOrderToLightClientWasmOrder, GetTransactionsResponse, TxWithCell, TxWithCells, lightClientGetTransactionsResultTo, LightClientLocalNode, LightClientRemoteNode, LightClientScriptStatus, NetworkSetting, GetCellsResponse, getCellsResponseFrom, LightClientWorkerInitializeOptions, TraceRecord } from "./types.ts";
+import { FetchResponse, LocalNode, localNodeTo, RemoteNode, remoteNodeTo, ScriptStatus, scriptStatusFrom, scriptStatusTo, LightClientSetScriptsCommand, transformFetchResponse, cccOrderToLightClientWasmOrder, GetTransactionsResponse, TxWithCell, TxWithCells, lightClientGetTransactionsResultTo, LightClientLocalNode, LightClientRemoteNode, LightClientScriptStatus, NetworkSetting, GetCellsResponse, getCellsResponseFrom, LightClientWorkerInitializeOptions, TraceRecord, RecordType } from "./types.ts";
 import { ClientBlock, ClientBlockHeader, Hex, hexFrom, HexLike, Num, numFrom, NumLike, numToHex, TransactionLike } from "@ckb-ccc/core/barrel";
 import { JsonRpcBlockHeader, JsonRpcTransformers } from "@ckb-ccc/core/advancedBarrel";
 import { Mutex } from "async-mutex";
@@ -291,10 +291,11 @@ class LightClient {
     }
     /**
      * Count how many records are in the IndexedDB store
+     * @param RecordType to filter
      * @returns The count.
      */
-    async getStoreRecordCount(): Promise<number> {
-        return await this.invokeLightClientCommand("get_store_record_count");
+    async getStoreRecordCount(recordType: RecordType): Promise<number> {
+        return await this.invokeLightClientCommand("get_store_record_count", [recordType]);
     }
 }
 

--- a/wasm/light-client-js/src/index.ts
+++ b/wasm/light-client-js/src/index.ts
@@ -289,7 +289,13 @@ class LightClient {
     async fetchTransaction(txHash: HexLike): Promise<FetchResponse<ClientTransactionResponse>> {
         return transformFetchResponse<any, ClientTransactionResponse>(await this.invokeLightClientCommand("fetch_transaction", [hexFrom(txHash)]), JsonRpcTransformers.transactionResponseTo);
     }
-
+    /**
+     * Count how many records are in the IndexedDB store
+     * @returns The count.
+     */
+    async getStoreRecordCount(): Promise<number> {
+        return await this.invokeLightClientCommand("get_store_record_count");
+    }
 }
 
 export { LightClient };

--- a/wasm/light-client-js/src/types.ts
+++ b/wasm/light-client-js/src/types.ts
@@ -319,6 +319,8 @@ type TraceRecord = {
     stop_at: number;
 };
 
+type RecordType = "all" | "transaction" | "cell_lock_script" | "cell_type_script" | "tx_lock_script" | "tx_type_script" | "block_by_hash" | "block_by_number" | "check_point_index" | "meta";
+
 export {
     LightClientFunctionCall,
     WorkerInitializeOptions,
@@ -341,5 +343,6 @@ export {
     GetCellsResponse,
     TraceRecord,
     Num,
-    Transaction
+    Transaction,
+    RecordType
 }

--- a/wasm/light-client-wasm/Cargo.toml
+++ b/wasm/light-client-wasm/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2.63"
 ckb-light-client-lib = { path = "../../light-client-lib" }
-
+light-client-db-common = { path = "../light-client-db-common" }
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/wasm/light-client-wasm/src/lib.rs
+++ b/wasm/light-client-wasm/src/lib.rs
@@ -1265,6 +1265,12 @@ pub fn fetch_transaction(tx_hash: &str) -> Result<JsValue, JsValue> {
     .serialize(&SERIALIZER)?)
 }
 
+#[wasm_bindgen]
+pub fn get_store_record_count() -> usize {
+    let swc = STORAGE_WITH_DATA.get().unwrap();
+    swc.storage().get_store_record_count()
+}
+
 const MAX_PREFIX_SEARCH_SIZE: usize = u16::MAX as usize;
 
 // a helper fn to build query options from search paramters, returns prefix, from_key, direction and skip offset

--- a/wasm/light-client-wasm/src/lib.rs
+++ b/wasm/light-client-wasm/src/lib.rs
@@ -26,6 +26,7 @@ use ckb_light_client_lib::{
     types::RunEnv,
     verify::verify_tx,
 };
+use light_client_db_common::GetRecordCountType;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::Serializer;
@@ -1266,9 +1267,12 @@ pub fn fetch_transaction(tx_hash: &str) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen]
-pub fn get_store_record_count() -> usize {
+pub fn get_store_record_count(record_type: JsValue) -> Result<usize, JsValue> {
+    let record_type: GetRecordCountType = serde_wasm_bindgen::from_value(record_type)
+        .map_err(|e| format!("Invalid record type: {}", e))?;
+
     let swc = STORAGE_WITH_DATA.get().unwrap();
-    swc.storage().get_store_record_count()
+    Ok(swc.storage().get_store_record_count(record_type))
 }
 
 const MAX_PREFIX_SEARCH_SIZE: usize = u16::MAX as usize;


### PR DESCRIPTION
Provide some basic database API to query database usage, currently there is only one API:
- `LightClient.getStoreRecordCount()`: Returns how many records are in the light client store