### PR TITLE
fix: Ensure pagination cursor updates for all cases in `get_cells` and `get_transactions`

### DIFF
--- a/light-client-bin/src/rpc.rs
+++ b/light-client-bin/src/rpc.rs
@@ -192,6 +192,8 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
         let cells = iter
             .take_while(|(key, _value)| key.starts_with(&prefix))
             .filter_map(|(key, value)| {
+                last_key = key.to_vec();
+
                 let tx_hash = packed::Byte32::from_slice(&value).expect("stored tx hash");
                 let output_index = u32::from_be_bytes(
                     key[key.len() - 4..]
@@ -288,8 +290,6 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
                         return None;
                     }
                 }
-
-                last_key = key.to_vec();
 
                 Some(Cell {
                     output: output.into(),
@@ -479,6 +479,7 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
             let txs = iter
                 .take_while(|(key, _value)| key.starts_with(&prefix))
                 .filter_map(|(key, value)| {
+                    last_key = key.to_vec();
                     let tx_hash = packed::Byte32::from_slice(&value).expect("stored tx hash");
                     let tx = packed::Transaction::from_slice(
                         &snapshot
@@ -554,7 +555,6 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
                         }
                     }
 
-                    last_key = key.to_vec();
                     Some(Tx::Ungrouped(TxWithCell {
                         transaction: tx.into_view().into(),
                         block_number: block_number.into(),

--- a/wasm/light-client-wasm/src/lib.rs
+++ b/wasm/light-client-wasm/src/lib.rs
@@ -604,6 +604,7 @@ pub fn get_cells(
     let mut last_key = Vec::new();
     for (key, value) in kvs.into_iter().map(|kv| (kv.key, kv.value)) {
         debug!("get cells iterator at {:?} {:?}", key, value);
+        last_key = key.to_vec();
         let tx_hash = packed::Byte32::from_slice(&value).expect("stored tx hash");
         let output_index = u32::from_be_bytes(
             key[key.len() - 4..]
@@ -708,7 +709,6 @@ pub fn get_cells(
             }
         }
 
-        last_key = key.to_vec();
         let cell_to_push = Cell {
             output: output.into(),
             output_data: if with_data {
@@ -925,6 +925,7 @@ pub fn get_transactions(
         let mut last_key = Vec::new();
         let mut txs = Vec::new();
         for (key, value) in kvs.into_iter().map(|kv| (kv.key, kv.value)) {
+            last_key = key.to_vec();
             let tx_hash = packed::Byte32::from_slice(&value).expect("stored tx hash");
             let tx = packed::Transaction::from_slice(
                 &storage
@@ -1008,7 +1009,6 @@ pub fn get_transactions(
                 }
             }
 
-            last_key = key.to_vec();
             txs.push(Tx::Ungrouped(TxWithCell {
                 transaction: tx.into_view().into(),
                 block_number: block_number.into(),


### PR DESCRIPTION
As the title goes, I notice pagination cursor in some corner cases does not get updated and results in infinite loops. The root cause is pagination cursor update is skipped when certain edge conditions are met simultaneously for example:
- When the query limit is small (e.g. 1 cell/transaction).
- And all cells/transactions are filtered out (e.g. 1 cell/transaction) - skipping pagination cursor update(the updater is below the loop continuer so it is skipped).

Please check this out!
BR,