### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-light-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "ckb-async-runtime",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-light-client-lib"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "ckb-app-config",

--- a/light-client-bin/Cargo.toml
+++ b/light-client-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/light-client-lib/Cargo.toml
+++ b/light-client-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-light-client-lib"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
 license = "MIT"

--- a/wasm/light-client-js/package.json
+++ b/wasm/light-client-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-light-client-js",
   "repository": "https://github.com/nervosnetwork/ckb-light-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This PR updated version of ckb-light-client-{bin, lib} and light-client-js to 0.5.2