### PR TITLE
Fix stack overflow on windows CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = [
-	"-C", "link-arg=/STACK:800000000"
-]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+	"-C", "link-arg=/STACK:800000000"
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
     branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ]
+  workflow_dispatch: 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
@@ -76,6 +77,10 @@ jobs:
           echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           scoop install llvm yasm
+      - name: Setup stack size on Windows
+        if: matrix.os == 'windows-2022'
+        run: |
+          $env:RUSTFLAGS="-C link-args=/STACK:67108864"
       - name: Build
         run: make build
       - name: UnitTest


### PR DESCRIPTION
CI on windows sometimes may trigger a stack overflow (See https://github.com/nervosnetwork/ckb-light-client/actions/runs/17406002472/job/49411220306), this PR fixes it by increasing default stack size.

```
       ABORT [   0.445s] ckb-light-client::bin/ckb-light-client tests::service::test_set_scripts_partial_min_filtered_block_number_bug
           - with code 0xc0000409: The system detected an overrun of a stack-based buffer in this application. This overrun could potentially allow a malicious user to gain control of this application. (os error 1282)
  stdout ───
```