### PR TITLE
Use tikv-jemallocator on non msvc platform and set rocksdb options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "tempfile",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -4165,6 +4166,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/light-client-bin/Cargo.toml
+++ b/light-client-bin/Cargo.toml
@@ -33,6 +33,9 @@ rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
 env_logger = "0.11"
 anyhow = "1.0.56"
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dev-dependencies]
 rand = "0.8"
 serde_json = "1.0"

--- a/light-client-bin/src/main.rs
+++ b/light-client-bin/src/main.rs
@@ -9,6 +9,10 @@ mod tests;
 use cli::AppConfig;
 use env_logger::{Builder, Env, Target};
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() -> anyhow::Result<()> {
     let mut builder = Builder::from_env(Env::default());
     builder.target(Target::Stdout);

--- a/light-client-lib/src/storage/db/native.rs
+++ b/light-client-lib/src/storage/db/native.rs
@@ -21,7 +21,7 @@ use ckb_types::{
 use rocksdb::{
     ops::{Delete, GetPinned},
     prelude::{Get, Iterate, Open, Put, WriteOps},
-    DBPinnableSlice, Direction, IteratorMode, Snapshot, WriteBatch, DB,
+    DBPinnableSlice, Direction, IteratorMode, Options, Snapshot, WriteBatch, DB,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -52,7 +52,12 @@ pub struct Storage {
 
 impl Storage {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
-        let db = Arc::new(DB::open_default(path).expect("Failed to open rocksdb"));
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.set_max_total_wal_size(128 * 1024 * 1024);
+        opts.set_write_buffer_size(128 * 1024 * 1024);
+        opts.set_max_write_buffer_number(2);
+        let db = Arc::new(DB::open(&opts, path).expect("Failed to open rocksdb"));
         Self { db }
     }
 


### PR DESCRIPTION
The rust default mem allocator may have memory leak issue when synchronizing.