### PR TITLE
relayer: remove RelayV2 init code

### DIFF
--- a/light-client-bin/src/subcmds.rs
+++ b/light-client-bin/src/subcmds.rs
@@ -69,20 +69,8 @@ impl RunConfig {
             BAD_MESSAGE_ALLOWED_EACH_HOUR,
         ));
         let sync_protocol = SyncProtocol::new(storage.clone(), Arc::clone(&peers));
-        let relay_protocol_v2 = RelayProtocol::new(
-            pending_txs.clone(),
-            Arc::clone(&peers),
-            consensus.clone(),
-            storage.clone(),
-            false,
-        );
-        let relay_protocol_v3 = RelayProtocol::new(
-            pending_txs.clone(),
-            Arc::clone(&peers),
-            consensus.clone(),
-            storage.clone(),
-            true,
-        );
+        let relay_protocol =
+            RelayProtocol::new(pending_txs.clone(), Arc::clone(&peers), storage.clone());
         let light_client: Box<dyn CKBProtocolHandler> = Box::new(LightClientProtocol::new(
             storage.clone(),
             Arc::clone(&peers),
@@ -97,13 +85,8 @@ impl RunConfig {
                 Arc::clone(&network_state),
             ),
             CKBProtocol::new_with_support_protocol(
-                SupportProtocols::RelayV2,
-                Box::new(relay_protocol_v2),
-                Arc::clone(&network_state),
-            ),
-            CKBProtocol::new_with_support_protocol(
                 SupportProtocols::RelayV3,
-                Box::new(relay_protocol_v3),
+                Box::new(relay_protocol),
                 Arc::clone(&network_state),
             ),
             CKBProtocol::new_with_support_protocol(

--- a/light-client-lib/src/protocols/relayer.rs
+++ b/light-client-lib/src/protocols/relayer.rs
@@ -1,4 +1,3 @@
-use ckb_chain_spec::consensus::Consensus;
 use ckb_network::{
     async_trait, bytes::Bytes, extract_peer_id, BoxedCKBProtocolContext, CKBProtocolHandler,
     PeerId, PeerIndex,
@@ -24,9 +23,7 @@ pub struct RelayProtocol {
     // Pending transactions which are waiting for relay
     pending_txs: Arc<RwLock<PendingTxs>>,
 
-    consensus: Consensus,
     storage: Storage,
-    v3: bool,
 }
 
 // a simple struct to store the pending transactions in memory with size limit
@@ -89,17 +86,13 @@ impl RelayProtocol {
     pub fn new(
         pending_txs: Arc<RwLock<PendingTxs>>,
         connected_peers: Arc<Peers>,
-        consensus: Consensus,
         storage: Storage,
-        v3: bool,
     ) -> Self {
         Self {
             opened_peers: HashMap::new(),
             pending_txs,
             connected_peers,
-            consensus,
             storage,
-            v3,
         }
     }
 }
@@ -141,29 +134,10 @@ impl CKBProtocolHandler for RelayProtocol {
             }
         };
 
-        let ckb2023 = self
-            .consensus
-            .hardfork_switch
-            .ckb2023
-            .is_vm_version_2_and_syscalls_3_enabled(epoch);
-
         debug!(
-            "RelayProtocol V{}({}).connected peer={}, epoch={}",
-            if self.v3 { '3' } else { '2' },
-            version,
-            peer,
-            epoch
+            "RelayProtocol.connected peer={}, version={}, epoch={}",
+            peer, version, epoch
         );
-
-        if self.v3 && !ckb2023 {
-            debug!("peer={} is not ckb2023 enabled, ignore", peer);
-            return;
-        }
-
-        if !self.v3 && ckb2023 {
-            debug!("peer={} is ckb2023 enabled, ignore", peer);
-            return;
-        }
         let flag = read_lock!(self.pending_txs).is_not_empty_and_updated_at(60);
 
         if flag {

--- a/wasm/light-client-wasm/src/lib.rs
+++ b/wasm/light-client-wasm/src/lib.rs
@@ -188,20 +188,8 @@ pub async fn light_client(
     ));
 
     let sync_protocol = SyncProtocol::new(storage.clone(), Arc::clone(&peers));
-    let relay_protocol_v2 = RelayProtocol::new(
-        pending_txs.clone(),
-        Arc::clone(&peers),
-        consensus.clone(),
-        storage.clone(),
-        false,
-    );
-    let relay_protocol_v3 = RelayProtocol::new(
-        pending_txs.clone(),
-        Arc::clone(&peers),
-        consensus.clone(),
-        storage.clone(),
-        true,
-    );
+    let relay_protocol =
+        RelayProtocol::new(pending_txs.clone(), Arc::clone(&peers), storage.clone());
     let light_client: Box<dyn CKBProtocolHandler> = Box::new(LightClientProtocol::new(
         storage.clone(),
         Arc::clone(&peers),
@@ -217,13 +205,8 @@ pub async fn light_client(
             Arc::clone(&network_state),
         ),
         CKBProtocol::new_with_support_protocol(
-            SupportProtocols::RelayV2,
-            Box::new(relay_protocol_v2),
-            Arc::clone(&network_state),
-        ),
-        CKBProtocol::new_with_support_protocol(
             SupportProtocols::RelayV3,
-            Box::new(relay_protocol_v3),
+            Box::new(relay_protocol),
             Arc::clone(&network_state),
         ),
         CKBProtocol::new_with_support_protocol(


### PR DESCRIPTION
CKB has launched CKB 2023 hardfork, so we can remove Relayer V2 init related code.
