### PR TITLE
Refactor: Reduce wasm32 and non-wasm32 platform duplication code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ name = "ckb-light-client-lib"
 version = "0.5.3"
 dependencies = [
  "anyhow",
+ "async-trait",
  "ckb-app-config",
  "ckb-chain",
  "ckb-chain-spec",

--- a/light-client-lib/Cargo.toml
+++ b/light-client-lib/Cargo.toml
@@ -47,6 +47,7 @@ anyhow = "1.0.56"
 thiserror = "1.0.30"
 toml = "0.5.8"
 tokio = { version = "1.20" }
+async-trait = "0.1.56"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [

--- a/light-client-lib/src/error.rs
+++ b/light-client-lib/src/error.rs
@@ -2,6 +2,8 @@ use std::{fmt, result};
 
 use thiserror::Error;
 
+pub mod db;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("config error: {0}")]
@@ -11,20 +13,8 @@ pub enum Error {
     #[error("runtime error: {0}")]
     Runtime(String),
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[error("db error: {0}")]
-    Db(#[from] rocksdb::Error),
-
-    #[cfg(target_arch = "wasm32")]
-    #[error("db error: {0}")]
-    Indexdb(String),
-}
-
-#[cfg(target_arch = "wasm32")]
-impl From<idb::Error> for Error {
-    fn from(value: idb::Error) -> Self {
-        Error::Indexdb(value.to_string())
-    }
+    Db(#[from] db::DatabaseError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/light-client-lib/src/error/db.rs
+++ b/light-client-lib/src/error/db.rs
@@ -1,0 +1,22 @@
+//! Cross-platform database error.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use rocksdb::Error as DatabaseError;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug)]
+pub struct DatabaseError(String);
+
+#[cfg(target_arch = "wasm32")]
+impl std::fmt::Display for DatabaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<idb::Error> for DatabaseError {
+    fn from(value: idb::Error) -> Self {
+        DatabaseError(value.to_string())
+    }
+}

--- a/light-client-lib/src/lib.rs
+++ b/light-client-lib/src/lib.rs
@@ -8,6 +8,8 @@ pub mod error;
 pub mod protocols;
 pub mod service;
 pub mod storage;
+pub mod sync;
+pub mod time;
 pub mod types;
 pub mod utils;
 pub mod verify;

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -2,6 +2,7 @@ use super::{components, BAD_MESSAGE_BAN_TIME};
 use crate::protocols::{Peers, Status, StatusCode};
 use crate::storage::Storage;
 use crate::sync::{RwLock, RwLockExt};
+use crate::time::{Duration, Instant};
 use crate::utils::network::prove_or_download_matched_blocks;
 use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
 use ckb_network::{
@@ -12,7 +13,6 @@ use golomb_coded_set::{GCSFilterReader, SipHasher24Builder, M, P};
 use log::{debug, info, log_enabled, trace, warn, Level};
 use rand::seq::SliceRandom as _;
 use std::io::Cursor;
-use crate::time::{Duration, Instant};
 use std::sync::Arc;
 
 pub(crate) const GET_BLOCK_FILTERS_TOKEN: u64 = 0;
@@ -90,7 +90,11 @@ impl FilterProtocol {
         self.peers
             .update_min_filtered_block_number(block_number)
             .await;
-        self.last_ask_time.write_ext().await.unwrap().replace(Instant::now());
+        self.last_ask_time
+            .write_ext()
+            .await
+            .unwrap()
+            .replace(Instant::now());
     }
     pub(crate) async fn try_send_get_block_filters(
         &self,

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -12,11 +12,8 @@ use golomb_coded_set::{GCSFilterReader, SipHasher24Builder, M, P};
 use log::{debug, info, log_enabled, trace, warn, Level};
 use rand::seq::SliceRandom as _;
 use std::io::Cursor;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
-use std::{sync::Arc, time::Duration};
-#[cfg(target_arch = "wasm32")]
-use web_time::Instant;
+use crate::time::{Duration, Instant};
+use std::sync::Arc;
 
 pub(crate) const GET_BLOCK_FILTERS_TOKEN: u64 = 0;
 pub(crate) const GET_BLOCK_FILTER_HASHES_TOKEN: u64 = 1;

--- a/light-client-lib/src/protocols/filter/block_filter.rs
+++ b/light-client-lib/src/protocols/filter/block_filter.rs
@@ -1,7 +1,7 @@
 use super::{components, BAD_MESSAGE_BAN_TIME};
 use crate::protocols::{Peers, Status, StatusCode};
 use crate::storage::Storage;
-use crate::types::RwLock;
+use crate::sync::{RwLock, RwLockExt};
 use crate::utils::network::prove_or_download_matched_blocks;
 use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
 use ckb_network::{
@@ -82,33 +82,18 @@ impl FilterProtocol {
     }
 
     async fn should_ask(&self, immediately: bool) -> bool {
-        #[cfg(target_arch = "wasm32")]
-        let result = !self.storage.is_filter_scripts_empty()
+        let last_ask_time = self.last_ask_time.read_ext().await.unwrap();
+        !self.storage.is_filter_scripts_empty()
             && (immediately
-                || self.last_ask_time.read().await.is_none()
-                || self.last_ask_time.read().await.unwrap().elapsed() > GET_BLOCK_FILTERS_TIMEOUT);
-        #[cfg(not(target_arch = "wasm32"))]
-        let result = !self.storage.is_filter_scripts_empty()
-            && (immediately
-                || self.last_ask_time.read().unwrap().is_none()
-                || self.last_ask_time.read().unwrap().unwrap().elapsed()
-                    > GET_BLOCK_FILTERS_TIMEOUT);
-
-        result
+                || last_ask_time.is_none()
+                || last_ask_time.unwrap().elapsed() > GET_BLOCK_FILTERS_TIMEOUT)
     }
-    #[cfg(target_arch = "wasm32")]
     pub async fn update_min_filtered_block_number(&self, block_number: BlockNumber) {
         self.storage.update_min_filtered_block_number(block_number);
         self.peers
             .update_min_filtered_block_number(block_number)
             .await;
-        self.last_ask_time.write().await.replace(Instant::now());
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn update_min_filtered_block_number(&self, block_number: BlockNumber) {
-        self.storage.update_min_filtered_block_number(block_number);
-        self.peers.update_min_filtered_block_number(block_number);
-        self.last_ask_time.write().unwrap().replace(Instant::now());
+        self.last_ask_time.write_ext().await.unwrap().replace(Instant::now());
     }
     pub(crate) async fn try_send_get_block_filters(
         &self,
@@ -129,12 +114,8 @@ impl FilterProtocol {
             let finalized_check_point_number = self
                 .peers
                 .calc_check_point_number(finalized_check_point_index);
-            #[cfg(target_arch = "wasm32")]
             let (cached_check_point_index, cached_hashes) =
                 self.peers.get_cached_block_filter_hashes().await;
-            #[cfg(not(target_arch = "wasm32"))]
-            let (cached_check_point_index, cached_hashes) =
-                self.peers.get_cached_block_filter_hashes();
 
             let cached_check_point_number =
                 self.peers.calc_check_point_number(cached_check_point_index);
@@ -213,19 +194,12 @@ impl FilterProtocol {
 
     pub(crate) async fn try_send_get_block_filter_hashes(&self, nc: BoxedCKBProtocolContext) {
         let min_filtered_block_number = self.storage.get_min_filtered_block_number();
-        #[cfg(target_arch = "wasm32")]
         self.peers
             .update_min_filtered_block_number(min_filtered_block_number)
             .await;
-        #[cfg(not(target_arch = "wasm32"))]
-        self.peers
-            .update_min_filtered_block_number(min_filtered_block_number);
 
         let finalized_check_point_index = self.storage.get_max_check_point_index();
-        #[cfg(target_arch = "wasm32")]
         let cached_check_point_index = self.peers.get_cached_block_filter_hashes().await.0;
-        #[cfg(not(target_arch = "wasm32"))]
-        let cached_check_point_index = self.peers.get_cached_block_filter_hashes().0;
 
         if let Some(start_number) = self
             .peers

--- a/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
@@ -67,12 +67,8 @@ impl<'a> BlockFilterHashesProcess<'a> {
             .protocol
             .peers
             .calc_check_point_number(finalized_check_point_index);
-        #[cfg(target_arch = "wasm32")]
         let (cached_check_point_index, cached_hashes) =
             self.protocol.peers.get_cached_block_filter_hashes().await;
-        #[cfg(not(target_arch = "wasm32"))]
-        let (cached_check_point_index, cached_hashes) =
-            self.protocol.peers.get_cached_block_filter_hashes();
 
         let cached_check_point_number = self
             .protocol

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -105,12 +105,8 @@ impl<'a> BlockFiltersProcess<'a> {
         let (mut parent_block_filter_hash, expected_block_filter_hashes) =
             if start_number <= finalized_check_point_number {
                 // Use cached block filter hashes to check the block filters.
-                #[cfg(target_arch = "wasm32")]
                 let (cached_check_point_index, mut cached_block_filter_hashes) =
                     self.filter.peers.get_cached_block_filter_hashes().await;
-                #[cfg(not(target_arch = "wasm32"))]
-                let (cached_check_point_index, mut cached_block_filter_hashes) =
-                    self.filter.peers.get_cached_block_filter_hashes();
 
                 let cached_check_point_number = self
                     .filter
@@ -250,13 +246,9 @@ impl<'a> BlockFiltersProcess<'a> {
                 .storage
                 .update_block_number(filtered_block_number)
         }
-        #[cfg(target_arch = "wasm32")]
         self.filter
             .update_min_filtered_block_number(filtered_block_number)
             .await;
-        #[cfg(not(target_arch = "wasm32"))]
-        self.filter
-            .update_min_filtered_block_number(filtered_block_number);
 
         let could_request_more_block_filters = self
             .filter

--- a/light-client-lib/src/protocols/filter/mod.rs
+++ b/light-client-lib/src/protocols/filter/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use crate::time::Duration;
 
 mod block_filter;
 mod components;

--- a/light-client-lib/src/protocols/light_client/constant.rs
+++ b/light-client-lib/src/protocols/light_client/constant.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use crate::time::Duration;
 
 pub const REFRESH_PEERS_TOKEN: u64 = 0;
 pub const FETCH_HEADER_TX_TOKEN: u64 = 1;

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -20,7 +20,7 @@ use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, Quota,
 use super::prelude::*;
 use crate::{
     protocols::{Status, StatusCode, BAD_MESSAGE_ALLOWED_EACH_HOUR, MESSAGE_TIMEOUT},
-    types::{Mutex, RwLock},
+    sync::{Mutex, MutexExt, RwLock, RwLockExt},
 };
 
 pub type BadMessageRateLimiter<T> = RateLimiter<T, DefaultKeyedStateStore<T>, DefaultClock>;
@@ -1299,10 +1299,7 @@ impl Peers {
         self.mark_fetching_headers_timeout(index);
         self.mark_fetching_txs_timeout(index);
         self.inner.remove(&index);
-        #[cfg(target_arch = "wasm32")]
-        self.rate_limiter.lock().await.retain_recent();
-        #[cfg(not(target_arch = "wasm32"))]
-        let _ignore_error = self.rate_limiter.lock().map(|inner| inner.retain_recent());
+        self.rate_limiter.lock_ext().await.unwrap().retain_recent();
     }
 
     pub(crate) fn get_peers_index(&self) -> Vec<PeerIndex> {
@@ -1644,53 +1641,25 @@ impl Peers {
             Err(StatusCode::PeerIsNotFound.into())
         }
     }
-    #[cfg(target_arch = "wasm32")]
     pub(crate) async fn update_min_filtered_block_number(
         &self,
         min_filtered_block_number: BlockNumber,
     ) {
         let should_cached_check_point_index =
             self.calc_cached_check_point_index_when_sync_at(min_filtered_block_number + 1);
-        let current_cached_check_point_index = self.cached_block_filter_hashes.read().await.0;
+        let current_cached_check_point_index = self.cached_block_filter_hashes.read_ext().await.unwrap().0;
         if current_cached_check_point_index != should_cached_check_point_index {
-            let mut tmp = self.cached_block_filter_hashes.write().await;
-            tmp.0 = should_cached_check_point_index;
-            tmp.1.clear();
-        }
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn update_min_filtered_block_number(&self, min_filtered_block_number: BlockNumber) {
-        let should_cached_check_point_index =
-            self.calc_cached_check_point_index_when_sync_at(min_filtered_block_number + 1);
-        let current_cached_check_point_index =
-            self.cached_block_filter_hashes.read().expect("poisoned").0;
-        if current_cached_check_point_index != should_cached_check_point_index {
-            let mut tmp = self.cached_block_filter_hashes.write().expect("poisoned");
+            let mut tmp = self.cached_block_filter_hashes.write_ext().await.unwrap();
             tmp.0 = should_cached_check_point_index;
             tmp.1.clear();
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
     pub(crate) async fn get_cached_block_filter_hashes(&self) -> (u32, Vec<packed::Byte32>) {
-        self.cached_block_filter_hashes.read().await.clone()
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn get_cached_block_filter_hashes(&self) -> (u32, Vec<packed::Byte32>) {
-        self.cached_block_filter_hashes
-            .read()
-            .expect("poisoned")
-            .clone()
+        self.cached_block_filter_hashes.read_ext().await.unwrap().clone()
     }
     pub(crate) async fn update_cached_block_filter_hashes(&self, hashes: Vec<packed::Byte32>) {
-        #[cfg(target_arch = "wasm32")]
-        {
-            self.cached_block_filter_hashes.write().await.1 = hashes;
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.cached_block_filter_hashes.write().expect("poisoned").1 = hashes;
-        }
+        self.cached_block_filter_hashes.write_ext().await.unwrap().1 = hashes;
     }
 
     pub(crate) async fn if_cached_block_filter_hashes_require_update(
@@ -1698,10 +1667,7 @@ impl Peers {
         finalized_check_point_index: u32,
     ) -> Option<BlockNumber> {
         let (cached_index, cached_length) = {
-            #[cfg(target_arch = "wasm32")]
-            let tmp = self.cached_block_filter_hashes.read().await;
-            #[cfg(not(target_arch = "wasm32"))]
-            let tmp = self.cached_block_filter_hashes.read().expect("poisoned");
+            let tmp = self.cached_block_filter_hashes.read_ext().await.unwrap();
             (tmp.0, tmp.1.len())
         };
         if cached_index >= finalized_check_point_index {
@@ -1884,10 +1850,7 @@ impl Peers {
             // Check:
             // - If cached block filter hashes is same check point as the required,
             // - If all block filter hashes in that check point are downloaded.
-            #[cfg(target_arch = "wasm32")]
             let cached_data = self.get_cached_block_filter_hashes().await;
-            #[cfg(not(target_arch = "wasm32"))]
-            let cached_data = self.get_cached_block_filter_hashes();
 
             let current_cached_check_point_index = cached_data.0;
             should_cached_check_point_index == current_cached_check_point_index

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -1647,7 +1647,8 @@ impl Peers {
     ) {
         let should_cached_check_point_index =
             self.calc_cached_check_point_index_when_sync_at(min_filtered_block_number + 1);
-        let current_cached_check_point_index = self.cached_block_filter_hashes.read_ext().await.unwrap().0;
+        let current_cached_check_point_index =
+            self.cached_block_filter_hashes.read_ext().await.unwrap().0;
         if current_cached_check_point_index != should_cached_check_point_index {
             let mut tmp = self.cached_block_filter_hashes.write_ext().await.unwrap();
             tmp.0 = should_cached_check_point_index;
@@ -1656,7 +1657,11 @@ impl Peers {
     }
 
     pub(crate) async fn get_cached_block_filter_hashes(&self) -> (u32, Vec<packed::Byte32>) {
-        self.cached_block_filter_hashes.read_ext().await.unwrap().clone()
+        self.cached_block_filter_hashes
+            .read_ext()
+            .await
+            .unwrap()
+            .clone()
     }
     pub(crate) async fn update_cached_block_filter_hashes(&self, hashes: Vec<packed::Byte32>) {
         self.cached_block_filter_hashes.write_ext().await.unwrap().1 = hashes;

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -1989,22 +1989,12 @@ impl Peers {
         if self.bad_message_allowed_each_hour == 0 {
             return true;
         }
-        #[cfg(target_arch = "wasm32")]
-        let result = self
-            .rate_limiter
-            .lock()
+        self.rate_limiter
+            .lock_ext()
             .await
+            .unwrap()
             .check_key(&peer_index)
-            .map_err(|_| ())
-            .is_err();
-        #[cfg(not(target_arch = "wasm32"))]
-        let result = self
-            .rate_limiter
-            .lock()
-            .map_err(|_| ())
-            .and_then(|inner| inner.check_key(&peer_index).map_err(|_| ()))
-            .is_err();
-        result
+            .is_err()
     }
 }
 

--- a/light-client-lib/src/protocols/mod.rs
+++ b/light-client-lib/src/protocols/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use crate::time::Duration;
 
 use ckb_types::core::BlockNumber;
 

--- a/light-client-lib/src/protocols/relayer.rs
+++ b/light-client-lib/src/protocols/relayer.rs
@@ -1,3 +1,4 @@
+use crate::time::{Duration, Instant};
 use ckb_chain_spec::consensus::Consensus;
 use ckb_network::{
     async_trait, bytes::Bytes, extract_peer_id, BoxedCKBProtocolContext, CKBProtocolHandler,
@@ -9,7 +10,6 @@ use linked_hash_map::LinkedHashMap;
 use log::{debug, trace, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use crate::time::{Duration, Instant};
 
 use crate::protocols::{Peers, BAD_MESSAGE_BAN_TIME};
 use crate::storage::Storage;
@@ -230,7 +230,11 @@ impl CKBProtocolHandler for RelayProtocol {
             message.item_name()
         );
         if let packed::RelayMessageUnionReader::GetRelayTransactions(reader) = message {
-            let pending_txs = self.pending_txs.read_ext().await.expect("read access should be OK");
+            let pending_txs = self
+                .pending_txs
+                .read_ext()
+                .await
+                .expect("read access should be OK");
             let relay_txs: Vec<_> = reader
                 .tx_hashes()
                 .iter()

--- a/light-client-lib/src/protocols/relayer.rs
+++ b/light-client-lib/src/protocols/relayer.rs
@@ -9,10 +9,7 @@ use linked_hash_map::LinkedHashMap;
 use log::{debug, trace, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{Duration, Instant};
-#[cfg(target_arch = "wasm32")]
-use web_time::{Duration, Instant};
+use crate::time::{Duration, Instant};
 
 use crate::protocols::{Peers, BAD_MESSAGE_BAN_TIME};
 use crate::storage::Storage;

--- a/light-client-lib/src/protocols/relayer.rs
+++ b/light-client-lib/src/protocols/relayer.rs
@@ -16,7 +16,7 @@ use web_time::{Duration, Instant};
 
 use crate::protocols::{Peers, BAD_MESSAGE_BAN_TIME};
 use crate::storage::Storage;
-use crate::types::RwLock;
+use crate::sync::{RwLock, RwLockExt};
 
 const CHECK_PENDING_TXS_TOKEN: u64 = 0;
 
@@ -167,17 +167,10 @@ impl CKBProtocolHandler for RelayProtocol {
             debug!("peer={} is ckb2023 enabled, ignore", peer);
             return;
         }
-        #[cfg(target_arch = "wasm32")]
         let flag = self
             .pending_txs
-            .read()
+            .read_ext()
             .await
-            .is_not_empty_and_updated_at(60);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let flag = self
-            .pending_txs
-            .read()
             .unwrap()
             .is_not_empty_and_updated_at(60);
 
@@ -186,16 +179,10 @@ impl CKBProtocolHandler for RelayProtocol {
                 .get_peer(peer)
                 .and_then(|p| extract_peer_id(&p.connected_addr))
                 .unwrap();
-            #[cfg(target_arch = "wasm32")]
             let tx_hashes = self
                 .pending_txs
-                .write()
+                .write_ext()
                 .await
-                .fetch_transaction_hashes_for_broadcast(peer_id);
-            #[cfg(not(target_arch = "wasm32"))]
-            let tx_hashes = self
-                .pending_txs
-                .write()
                 .unwrap()
                 .fetch_transaction_hashes_for_broadcast(peer_id);
             if !tx_hashes.is_empty() {
@@ -246,10 +233,7 @@ impl CKBProtocolHandler for RelayProtocol {
             message.item_name()
         );
         if let packed::RelayMessageUnionReader::GetRelayTransactions(reader) = message {
-            #[cfg(target_arch = "wasm32")]
-            let pending_txs = self.pending_txs.read().await;
-            #[cfg(not(target_arch = "wasm32"))]
-            let pending_txs = self.pending_txs.read().expect("read access should be OK");
+            let pending_txs = self.pending_txs.read_ext().await.expect("read access should be OK");
             let relay_txs: Vec<_> = reader
                 .tx_hashes()
                 .iter()
@@ -285,17 +269,10 @@ impl CKBProtocolHandler for RelayProtocol {
             CHECK_PENDING_TXS_TOKEN => {
                 // we check pending txs every 2 seconds, if the timestamp of the pending txs is updated in the last minute
                 // and connected relay protocol peers is empty, we try to open the protocol and broadcast the pending txs
-                #[cfg(target_arch = "wasm32")]
                 let flag = self
                     .pending_txs
-                    .read()
+                    .read_ext()
                     .await
-                    .is_not_empty_and_updated_at(60);
-
-                #[cfg(not(target_arch = "wasm32"))]
-                let flag = self
-                    .pending_txs
-                    .read()
                     .unwrap()
                     .is_not_empty_and_updated_at(60);
 
@@ -310,10 +287,7 @@ impl CKBProtocolHandler for RelayProtocol {
                         }
                     }
                 } else {
-                    #[cfg(target_arch = "wasm32")]
-                    let mut pending_txs = self.pending_txs.write().await;
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let mut pending_txs = self.pending_txs.write().unwrap();
+                    let mut pending_txs = self.pending_txs.write_ext().await.unwrap();
                     for (&peer, instant) in self.opened_peers.iter_mut() {
                         if let Some(peer_id) = nc
                             .get_peer(peer)

--- a/light-client-lib/src/storage/mod.rs
+++ b/light-client-lib/src/storage/mod.rs
@@ -25,7 +25,7 @@ pub use db::{Batch, Storage};
 
 use crate::{
     protocols::{Peers, PendingTxs},
-    types::RwLock,
+    sync::RwLock,
 };
 
 pub const LAST_STATE_KEY: &str = "LAST_STATE";

--- a/light-client-lib/src/storage/mod.rs
+++ b/light-client-lib/src/storage/mod.rs
@@ -18,9 +18,7 @@ use ckb_types::{
 mod db;
 
 #[cfg(target_arch = "wasm32")]
-pub use db::{Batch, CursorDirection, Storage};
-
-#[cfg(not(target_arch = "wasm32"))]
+pub use db::CursorDirection;
 pub use db::{Batch, Storage};
 
 use crate::{

--- a/light-client-lib/src/sync.rs
+++ b/light-client-lib/src/sync.rs
@@ -1,0 +1,57 @@
+//! Cross-platform synchronization primitives.
+
+#[cfg(target_arch = "wasm32")]
+pub use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[async_trait::async_trait]
+pub trait RwLockExt<T> {
+    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>>;
+    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait::async_trait]
+impl<T: Send + Sync> RwLockExt<T> for RwLock<T> {
+    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
+        tokio::task::block_in_place(|| self.read())
+    }
+
+    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
+        tokio::task::block_in_place(|| self.write())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait::async_trait]
+impl<T: Send + Sync> RwLockExt<T> for RwLock<T> {
+    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
+        Ok(self.read().await)
+    }
+
+    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
+        Ok(self.write().await)
+    }
+}
+
+#[async_trait::async_trait]
+pub trait MutexExt<T> {
+    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait::async_trait]
+impl<T: Send> MutexExt<T> for Mutex<T> {
+    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
+        tokio::task::block_in_place(|| self.lock())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait::async_trait]
+impl<T: Send> MutexExt<T> for Mutex<T> {
+    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
+        Ok(self.lock().await)
+    }
+}

--- a/light-client-lib/src/sync.rs
+++ b/light-client-lib/src/sync.rs
@@ -1,24 +1,32 @@
 //! Cross-platform synchronization primitives.
 
-#[cfg(target_arch = "wasm32")]
-pub use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(not(target_arch = "wasm32"))]
 pub use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(target_arch = "wasm32")]
+pub use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[async_trait::async_trait]
 pub trait RwLockExt<T> {
-    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>>;
-    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>>;
+    async fn read_ext(
+        &self,
+    ) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>>;
+    async fn write_ext(
+        &self,
+    ) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl<T: Send + Sync> RwLockExt<T> for RwLock<T> {
-    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
+    async fn read_ext(
+        &self,
+    ) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
         tokio::task::block_in_place(|| self.read())
     }
 
-    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
+    async fn write_ext(
+        &self,
+    ) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
         tokio::task::block_in_place(|| self.write())
     }
 }
@@ -26,24 +34,32 @@ impl<T: Send + Sync> RwLockExt<T> for RwLock<T> {
 #[cfg(target_arch = "wasm32")]
 #[async_trait::async_trait]
 impl<T: Send + Sync> RwLockExt<T> for RwLock<T> {
-    async fn read_ext(&self) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
+    async fn read_ext(
+        &self,
+    ) -> Result<RwLockReadGuard<'_, T>, std::sync::PoisonError<RwLockReadGuard<'_, T>>> {
         Ok(self.read().await)
     }
 
-    async fn write_ext(&self) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
+    async fn write_ext(
+        &self,
+    ) -> Result<RwLockWriteGuard<'_, T>, std::sync::PoisonError<RwLockWriteGuard<'_, T>>> {
         Ok(self.write().await)
     }
 }
 
 #[async_trait::async_trait]
 pub trait MutexExt<T> {
-    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>>;
+    async fn lock_ext(
+        &self,
+    ) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl<T: Send> MutexExt<T> for Mutex<T> {
-    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
+    async fn lock_ext(
+        &self,
+    ) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
         tokio::task::block_in_place(|| self.lock())
     }
 }
@@ -51,7 +67,9 @@ impl<T: Send> MutexExt<T> for Mutex<T> {
 #[cfg(target_arch = "wasm32")]
 #[async_trait::async_trait]
 impl<T: Send> MutexExt<T> for Mutex<T> {
-    async fn lock_ext(&self) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
+    async fn lock_ext(
+        &self,
+    ) -> Result<MutexGuard<'_, T>, std::sync::PoisonError<MutexGuard<'_, T>>> {
         Ok(self.lock().await)
     }
 }

--- a/light-client-lib/src/tests/protocols/block_filter.rs
+++ b/light-client-lib/src/tests/protocols/block_filter.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::time::Instant;
+use crate::time::Instant;
 
 use ckb_network::{bytes::Bytes, CKBProtocolHandler, PeerIndex, SupportProtocols};
 use ckb_store::ChainStore as _;

--- a/light-client-lib/src/tests/protocols/block_filter.rs
+++ b/light-client-lib/src/tests/protocols/block_filter.rs
@@ -1,6 +1,6 @@
+use crate::time::Instant;
 use std::sync::Arc;
 use std::sync::RwLock;
-use crate::time::Instant;
 
 use ckb_network::{bytes::Bytes, CKBProtocolHandler, PeerIndex, SupportProtocols};
 use ckb_store::ChainStore as _;

--- a/light-client-lib/src/tests/utils/network_context.rs
+++ b/light-client-lib/src/tests/utils/network_context.rs
@@ -1,9 +1,9 @@
+use crate::time::Duration;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use crate::time::Duration;
 
 use ckb_network::{
     async_trait, bytes::Bytes as P2pBytes, Behaviour, CKBProtocolContext, Error, Peer, PeerIndex,

--- a/light-client-lib/src/tests/utils/network_context.rs
+++ b/light-client-lib/src/tests/utils/network_context.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use crate::time::Duration;
 
 use ckb_network::{
     async_trait, bytes::Bytes as P2pBytes, Behaviour, CKBProtocolContext, Error, Peer, PeerIndex,

--- a/light-client-lib/src/time.rs
+++ b/light-client-lib/src/time.rs
@@ -1,0 +1,7 @@
+//! Cross-platform time primitives.
+
+#[cfg(target_arch = "wasm32")]
+pub use web_time::{Duration, Instant};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::{Duration, Instant};

--- a/light-client-lib/src/types.rs
+++ b/light-client-lib/src/types.rs
@@ -39,15 +39,4 @@ impl fmt::Display for RunEnv {
     }
 }
 
-/**
- * RwLock type used on wasm. On wasm, std::sync::RwLock doesn't work properly on single-thread async environment.
- */
-#[cfg(target_arch = "wasm32")]
-pub type RwLock<T> = tokio::sync::RwLock<T>;
-#[cfg(target_arch = "wasm32")]
-pub type Mutex<T> = tokio::sync::Mutex<T>;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub type RwLock<T> = std::sync::RwLock<T>;
-#[cfg(not(target_arch = "wasm32"))]
-pub type Mutex<T> = std::sync::Mutex<T>;

--- a/light-client-lib/src/types.rs
+++ b/light-client-lib/src/types.rs
@@ -38,5 +38,3 @@ impl fmt::Display for RunEnv {
             .and_then(|s| write!(f, "{}", s))
     }
 }
-
-


### PR DESCRIPTION
This PR want to reduce the duplicated codes for `wasm32` and `non-wasm32` platform.
Like:
Change:
```rust
        #[cfg(target_arch = "wasm32")]
        self.filter
            .update_min_filtered_block_number(filtered_block_number)
            .await;
        #[cfg(not(target_arch = "wasm32"))]
        self.filter
            .update_min_filtered_block_number(filtered_block_number);
```
to
```rust
        self.filter
            .update_min_filtered_block_number(filtered_block_number)
            .await;
```
