### PR TITLE
Show binary version, built time in `--version` and loging startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +767,7 @@ name = "ckb-light-client"
 version = "0.5.3"
 dependencies = [
  "anyhow",
+ "chrono",
  "ckb-async-runtime",
  "ckb-chain-spec",
  "ckb-jsonrpc-types",
@@ -768,6 +791,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tikv-jemallocator",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -1480,6 +1504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1653,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1719,46 @@ name = "data-encoding"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "derive_more"
@@ -2384,6 +2489,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2643,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3031,6 +3166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -3330,6 +3480,12 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4189,6 +4345,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,6 +4719,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "9.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,6 +5014,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"

--- a/light-client-bin/Cargo.toml
+++ b/light-client-bin/Cargo.toml
@@ -36,6 +36,10 @@ anyhow = "1.0.56"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"
 
+[build-dependencies]
+vergen-gitcl = { version = "1", default-features = false }
+chrono = "0.4"
+
 [dev-dependencies]
 rand = "0.8"
 serde_json = "1.0"

--- a/light-client-bin/build.rs
+++ b/light-client-bin/build.rs
@@ -1,0 +1,39 @@
+use std::process::Command;
+use vergen_gitcl::{Emitter, GitclBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let gitcl = GitclBuilder::default()
+        .sha(true)
+        .dirty(true)
+        .build()?;
+
+    Emitter::default()
+        .add_instructions(&gitcl)?
+        .emit()?;
+
+    // Check if git working directory is dirty and create a suffix
+    let is_dirty = Command::new("git")
+        .args(["diff-index", "--quiet", "HEAD", "--"])
+        .status()
+        .map(|status| !status.success())
+        .unwrap_or(false);
+
+    let dirty_suffix = if is_dirty { "-dirty" } else { "" };
+    println!("cargo:rustc-env=GIT_DIRTY_SUFFIX={}", dirty_suffix);
+
+    // Generate build timestamp without nanoseconds
+    let timestamp = if let Ok(epoch) = std::env::var("SOURCE_DATE_EPOCH") {
+        if let Ok(seconds) = epoch.parse::<i64>() {
+            chrono::DateTime::from_timestamp(seconds, 0)
+                .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+                .unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        } else {
+            chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+        }
+    } else {
+        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    };
+    println!("cargo:rustc-env=VERGEN_BUILD_TIMESTAMP={}", timestamp);
+
+    Ok(())
+}

--- a/light-client-bin/build.rs
+++ b/light-client-bin/build.rs
@@ -2,14 +2,9 @@ use std::process::Command;
 use vergen_gitcl::{Emitter, GitclBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let gitcl = GitclBuilder::default()
-        .sha(true)
-        .dirty(true)
-        .build()?;
+    let gitcl = GitclBuilder::default().sha(true).dirty(true).build()?;
 
-    Emitter::default()
-        .add_instructions(&gitcl)?
-        .emit()?;
+    Emitter::default().add_instructions(&gitcl)?.emit()?;
 
     // Check if git working directory is dirty and create a suffix
     let is_dirty = Command::new("git")

--- a/light-client-bin/src/cli.rs
+++ b/light-client-bin/src/cli.rs
@@ -15,8 +15,18 @@ pub(crate) struct RunConfig {
 
 impl AppConfig {
     pub(crate) fn load() -> Result<Self> {
+        let version = concat!(
+            env!("CARGO_PKG_VERSION"),
+            " (",
+            env!("VERGEN_GIT_SHA"),
+            env!("GIT_DIRTY_SUFFIX"),
+            " ",
+            env!("VERGEN_BUILD_TIMESTAMP"),
+            ")"
+        );
+
         let cmd = clap::Command::new("CKB Light Client")
-            .version(clap::crate_version!())
+            .version(version)
             .author(clap::crate_authors!("\n"))
             .about(clap::crate_description!())
             .subcommand_required(true)

--- a/light-client-bin/src/cli.rs
+++ b/light-client-bin/src/cli.rs
@@ -13,20 +13,34 @@ pub(crate) struct RunConfig {
     pub(crate) run_env: RunEnv,
 }
 
+pub fn binary_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+pub fn git_hash() -> &'static str {
+    concat!(env!("VERGEN_GIT_SHA"), env!("GIT_DIRTY_SUFFIX"))
+}
+
+pub fn build_time() -> &'static str {
+    env!("VERGEN_BUILD_TIMESTAMP")
+}
+
+fn version_info() -> &'static str {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (",
+        env!("VERGEN_GIT_SHA"),
+        env!("GIT_DIRTY_SUFFIX"),
+        " ",
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        ")"
+    )
+}
+
 impl AppConfig {
     pub(crate) fn load() -> Result<Self> {
-        let version = concat!(
-            env!("CARGO_PKG_VERSION"),
-            " (",
-            env!("VERGEN_GIT_SHA"),
-            env!("GIT_DIRTY_SUFFIX"),
-            " ",
-            env!("VERGEN_BUILD_TIMESTAMP"),
-            ")"
-        );
-
         let cmd = clap::Command::new("CKB Light Client")
-            .version(version)
+            .version(version_info())
             .author(clap::crate_authors!("\n"))
             .about(clap::crate_description!())
             .subcommand_required(true)

--- a/light-client-bin/src/main.rs
+++ b/light-client-bin/src/main.rs
@@ -20,7 +20,10 @@ fn main() -> anyhow::Result<()> {
         .try_init()
         .expect("env_logger builder init should be ok");
 
-    log::info!("Starting ...");
+    log::info!("Starting CKB Light Client ...");
+    log::info!("Version: {}", cli::binary_version());
+    log::info!("Git Hash: {}", cli::git_hash());
+    log::info!("Built Time: {}", cli::build_time());
 
     AppConfig::load()?.execute()?;
 


### PR DESCRIPTION
1. add git commit hash and built time in `--version`
```bash
❯ ./target/debug/ckb-light-client --version
CKB Light Client 0.5.3 (e1508cf-dirty 2025-12-10T02:43:23Z)
```

2. logging git commit hash and built time at startup.
```bash
[2025-12-10T02:47:34Z INFO  ckb_light_client] Starting CKB Light Client ...
[2025-12-10T02:47:34Z INFO  ckb_light_client] Version: 0.5.3
[2025-12-10T02:47:34Z INFO  ckb_light_client] Git Hash: e1508cf-dirty
[2025-12-10T02:47:34Z INFO  ckb_light_client] Built Time: 2025-12-10T02:43:23Z
[2025-12-10T02:47:34Z INFO  ckb_light_client::cli] Executing ...
[2025-12-10T02:47:34Z INFO  ckb_light_client::subcmds] Run ...


```