### PR TITLE
rpc: set_scripts do not really need thread::spawn

### DIFF
--- a/light-client-bin/src/rpc.rs
+++ b/light-client-bin/src/rpc.rs
@@ -135,17 +135,12 @@ impl BlockFilterRpc for BlockFilterRpcImpl {
         scripts: Vec<ScriptStatus>,
         command: Option<SetScriptsCommand>,
     ) -> Result<()> {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let swc = self.swc.clone();
-        std::thread::spawn(move || {
-            let mut matched_blocks = swc.matched_blocks().blocking_write();
-            let scripts = scripts.into_iter().map(Into::into).collect();
-            swc.storage()
-                .update_filter_scripts(scripts, command.map(Into::into).unwrap_or_default());
-            matched_blocks.clear();
-            tx.send(()).unwrap();
-        });
-        rx.recv().unwrap();
+        let mut matched_blocks = self.swc.matched_blocks().blocking_write();
+        let scripts = scripts.into_iter().map(Into::into).collect();
+        self.swc
+            .storage()
+            .update_filter_scripts(scripts, command.map(Into::into).unwrap_or_default());
+        matched_blocks.clear();
         Ok(())
     }
 


### PR DESCRIPTION
In 
```rust


impl BlockFilterRpc for BlockFilterRpcImpl {
    fn set_scripts(
        &self,
        scripts: Vec<ScriptStatus>,
        command: Option<SetScriptsCommand>,
    ) -> Result<()> {

```

set_scripts don't really need thread::spawn
