### PR TITLE
NodeJS support for light-client-wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /package-lock.json
 /.vscode
 /data
+/test-lightclient-node

--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
         "./wasm/light-client-db-worker",
         "./wasm/light-client-wasm",
         "./wasm/light-client-js"
-    ]
+    ],
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/wasm/light-client-db-worker/index.mts
+++ b/wasm/light-client-db-worker/index.mts
@@ -1,0 +1,16 @@
+import * as wasmModule from "./pkg/light-client-db-worker.js";
+import wasm from "./pkg/light-client-db-worker_bg.wasm"
+import "fake-indexeddb/auto"
+import path from "path";
+
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// const indexedDB = IndexedDB.create(destructible, path.join(__dirname, 'tmp', 'readme'))
+globalThis.indexedDB = indexedDB;
+
+wasmModule.initSync({ module: wasm });
+
+export default wasmModule;

--- a/wasm/light-client-db-worker/index.ts
+++ b/wasm/light-client-db-worker/index.ts
@@ -1,5 +1,0 @@
-import * as wasmModule from "./pkg/light-client-db-worker";
-import wasm from "./pkg/light-client-db-worker_bg.wasm"
-wasmModule.initSync({ module: wasm });
-
-export default wasmModule;

--- a/wasm/light-client-db-worker/package.json
+++ b/wasm/light-client-db-worker/package.json
@@ -6,6 +6,7 @@
         "serve": "webpack serve"
     },
     "devDependencies": {
+        "@types/node": "^25.0.2",
         "@wasm-tool/wasm-pack-plugin": "1.5.0",
         "arraybuffer-loader": "^1.0.8",
         "buffer": "^6.0.3",
@@ -16,5 +17,8 @@
         "webpack-cli": "^5.1.4"
     },
     "main": "dist/index.js",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "dependencies": {
+        "fake-indexeddb": "^6.2.5"
+    }
 }

--- a/wasm/light-client-db-worker/src/lib.rs
+++ b/wasm/light-client-db-worker/src/lib.rs
@@ -141,8 +141,8 @@ pub async fn main_loop(log_level: &str) {
                                 match wait_for_command_sync(&input_i32_arr, InputCommand::Waiting)
                                     .unwrap()
                                 {
-                                    s @ (InputCommand::Waiting
-                                    | InputCommand::OpenDatabase
+                                    InputCommand::Waiting => {},
+                                    s @ (InputCommand::OpenDatabase
                                     | InputCommand::Shutdown
                                     | InputCommand::ResponseTakeWhile) => {
                                         log::warn!(

--- a/wasm/light-client-db-worker/tsconfig.json
+++ b/wasm/light-client-db-worker/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "module": "es6",
+    "module": "nodenext",
     "target": "ES2015",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "sourceMap": true,
     "declaration": true,
     "declarationDir": "dist",

--- a/wasm/light-client-db-worker/webpack.config.js
+++ b/wasm/light-client-db-worker/webpack.config.js
@@ -2,8 +2,8 @@ const path = require('path');
 const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 const webpack = require("webpack");
 module.exports = {
-    entry: './index.ts',
-    target: "webworker",
+    entry: './index.mts',
+    target: "node",
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
@@ -19,9 +19,9 @@ module.exports = {
             outName: "light-client-db-worker",
             extraArgs: "--target web"
         }),
-        new webpack.ProvidePlugin({
-            Buffer: ['buffer', 'Buffer'],
-        }),
+        // new webpack.ProvidePlugin({
+        //     Buffer: ['buffer', 'Buffer'],
+        // }),
     ],
     module: {
         rules: [
@@ -40,9 +40,13 @@ module.exports = {
         outputModule: true
     },
     mode: "production",
-    resolve: {
-        fallback: {
-            buffer: require.resolve('buffer/'),
-        },
+    // resolve: {
+    //     fallback: {
+    //         buffer: require.resolve('buffer/'),
+    //     },
+    // },
+    node: {
+        global: false,
+        __dirname: false
     },
 };

--- a/wasm/light-client-js/esbuild.config.mjs
+++ b/wasm/light-client-js/esbuild.config.mjs
@@ -31,6 +31,6 @@ await esbuild.build({
         "stream"
     ],
     banner: {
-        js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+        js: "import { createRequire } from 'module'; import { fileURLToPath } from 'url'; import { dirname } from 'path'; const require = createRequire(import.meta.url); const __filename = fileURLToPath(import.meta.url); const __dirname = dirname(__filename);"
     }
 })

--- a/wasm/light-client-js/esbuild.config.mjs
+++ b/wasm/light-client-js/esbuild.config.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild'
-import inlineWorkerPlugin from 'esbuild-plugin-inline-worker';
+import inlineWorkerPlugin from './inline-worker-plugin.js';
 import { polyfillNode } from "esbuild-plugin-polyfill-node";
 import { dtsPlugin } from "esbuild-plugin-d.ts";
 import fs from "node:fs/promises";
@@ -10,16 +10,27 @@ await esbuild.build({
     entryPoints: ["./src/index.ts"],
     bundle: true,
     outdir: "dist",
-    plugins: [polyfillNode(), inlineWorkerPlugin({
+    plugins: [/*polyfillNode(),*/ inlineWorkerPlugin({
         format: "iife"
-    }), dtsPlugin({ tsconfig })],
+    }), /*dtsPlugin({ tsconfig })*/],
     target: [
         "esnext"
     ],
-    platform: "browser",
+    platform: "node",
     sourcemap: true,
     format: "esm",
     globalName: "CkbLightClient",
     minify: profile === "prod",
-    logLevel: "debug"
+    logLevel: "debug",
+    external: [
+        "ws",
+        "isomorphic-ws",
+        "events",
+        "buffer",
+        "util",
+        "stream"
+    ],
+    banner: {
+        js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+    }
 })

--- a/wasm/light-client-js/inline-worker-plugin.js
+++ b/wasm/light-client-js/inline-worker-plugin.js
@@ -1,0 +1,134 @@
+import { build } from "esbuild";
+import findCacheDir from "find-cache-dir";
+import fs from "fs";
+import path from "path";
+
+
+export default function inlineWorkerPlugin(
+    workerPluginConfig = {},
+) {
+    return {
+        name: "esbuild-plugin-inline-worker",
+
+        setup(build) {
+            build.onLoad(
+                { filter: /\.worker.(js|jsx|ts|tsx)$/ },
+                async ({ path: workerPath }) => {
+                    // const workerCode = await fs.promises.readFile(workerPath, {
+                    //   encoding: 'utf-8',
+                    // });
+
+                    const workerCode = await buildWorker(workerPath, workerPluginConfig);
+                    return {
+                        contents: `import inlineWorker from '__inline-worker'
+export default function Worker() {
+  return inlineWorker(${JSON.stringify(workerCode)});
+}
+`,
+                        loader: "js",
+                    };
+                },
+            );
+
+            const options = {
+                name: workerPluginConfig.workerName || undefined,
+                ...workerPluginConfig.workerArguments,
+            }
+
+            const inlineWorkerFunctionCode = `
+export default function inlineWorker(scriptText) {
+  // 检测是否在 Node.js 环境
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+    const { Worker } = require('worker_threads');
+    const fs = require('fs');
+    const path = require('path');
+    const os = require('os');
+    const crypto = require('crypto');
+    
+    // 生成临时文件路径
+    const hash = crypto.createHash('md5').update(scriptText).digest('hex').slice(0, 8);
+    const tempDir = os.tmpdir();
+    const tempFilePath = path.join(tempDir, \`worker-\${hash}-\${Date.now()}.mjs\`);
+    
+    // 写入临时文件
+    fs.writeFileSync(tempFilePath, scriptText, 'utf-8');
+    console.log('[inline-worker] Created temporary worker file:', tempFilePath);
+    
+    // 使用文件路径创建 Worker
+    const worker = new Worker(tempFilePath, ${JSON.stringify(options)});
+    
+    // 清理临时文件（在 worker 终止或错误时）
+    const cleanup = () => {
+      try {
+        if (fs.existsSync(tempFilePath)) {
+        //   fs.unlinkSync(tempFilePath);
+        //   console.log('[inline-worker] Cleaned up temporary worker file:', tempFilePath);
+        }
+      } catch (err) {
+        console.error('[inline-worker] Failed to cleanup temporary file:', err);
+      }
+    };
+    
+    worker.on('exit', cleanup);
+    // worker.on('error', cleanup);
+    worker.on('error', (err) => {
+      console.error('[inline-worker] Worker error:', err);
+      cleanup();
+    });
+    
+    return worker;
+  } else {
+    // 浏览器环境
+    const blob = new Blob([scriptText], {type: 'text/javascript'});
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url, ${JSON.stringify(options)});
+    URL.revokeObjectURL(url);
+    return worker;
+  }
+}
+`;
+
+            build.onResolve({ filter: /^__inline-worker$/ }, ({ path }) => {
+                return { path, namespace: "inline-worker" };
+            });
+            build.onLoad({ filter: /.*/, namespace: "inline-worker" }, () => {
+                return { contents: inlineWorkerFunctionCode, loader: "js" };
+            });
+        },
+    };
+}
+
+const cacheDir = findCacheDir({
+    name: "esbuild-plugin-inline-worker",
+    create: true,
+});
+
+async function buildWorker(workerPath, pluginConfig) {
+    const scriptNameParts = path.basename(workerPath).split(".");
+    scriptNameParts.pop();
+    scriptNameParts.push("js");
+    const scriptName = scriptNameParts.join(".");
+    if (!cacheDir) {
+        throw new Error("Cache directory not found. Please ensure 'find-cache-dir' is installed.");
+    }
+    const bundlePath = path.resolve(cacheDir, scriptName);
+
+    if (pluginConfig.buildOptions) {
+        delete pluginConfig.buildOptions.entryPoints;
+        delete pluginConfig.buildOptions.outfile;
+        delete pluginConfig.buildOptions.outdir;
+    }
+
+    await build({
+        entryPoints: [workerPath],
+        bundle: true,
+        minify: true,
+        outfile: bundlePath,
+        target: "esnext",
+        format: "esm",
+        platform: "node",
+        ...pluginConfig.buildOptions,
+    });
+
+    return fs.promises.readFile(bundlePath, { encoding: "utf-8" });
+}

--- a/wasm/light-client-js/inline-worker-plugin.js
+++ b/wasm/light-client-js/inline-worker-plugin.js
@@ -37,7 +37,6 @@ export default function Worker() {
 
             const inlineWorkerFunctionCode = `
 export default function inlineWorker(scriptText) {
-  // 检测是否在 Node.js 环境
   if (typeof process !== 'undefined' && process.versions && process.versions.node) {
     const { Worker } = require('worker_threads');
     const fs = require('fs');
@@ -45,19 +44,15 @@ export default function inlineWorker(scriptText) {
     const os = require('os');
     const crypto = require('crypto');
     
-    // 生成临时文件路径
     const hash = crypto.createHash('md5').update(scriptText).digest('hex').slice(0, 8);
     const tempDir = os.tmpdir();
     const tempFilePath = path.join(tempDir, \`worker-\${hash}-\${Date.now()}.mjs\`);
     
-    // 写入临时文件
     fs.writeFileSync(tempFilePath, scriptText, 'utf-8');
     console.log('[inline-worker] Created temporary worker file:', tempFilePath);
     
-    // 使用文件路径创建 Worker
     const worker = new Worker(tempFilePath, ${JSON.stringify(options)});
     
-    // 清理临时文件（在 worker 终止或错误时）
     const cleanup = () => {
       try {
         if (fs.existsSync(tempFilePath)) {
@@ -78,7 +73,6 @@ export default function inlineWorker(scriptText) {
     
     return worker;
   } else {
-    // 浏览器环境
     const blob = new Blob([scriptText], {type: 'text/javascript'});
     const url = URL.createObjectURL(blob);
     const worker = new Worker(url, ${JSON.stringify(options)});

--- a/wasm/light-client-js/package.json
+++ b/wasm/light-client-js/package.json
@@ -7,14 +7,14 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.14",
-    "esbuild": "0.24.2",
-    "esbuild-plugin-d.ts": "^1.3.1",
-    "esbuild-plugin-inline-worker": "^0.1.1",
-    "esbuild-plugin-polyfill-node": "^0.3.0",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
     "ckb-light-client-db-worker": "*",
-    "ckb-light-client-wasm": "*"
+    "ckb-light-client-wasm": "*",
+    "esbuild": "^0.27.1",
+    "esbuild-plugin-d.ts": "^1.3.1",
+    "esbuild-plugin-polyfill-node": "^0.3.0",
+    "find-cache-dir": "^5.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5"
   },
   "dependencies": {
     "@ckb-ccc/core": "0.1.0-alpha.6",

--- a/wasm/light-client-js/src/db.worker.ts
+++ b/wasm/light-client-js/src/db.worker.ts
@@ -1,14 +1,15 @@
 import { DbWorkerInitializeOptions } from "./types";
 import wasmModule from "ckb-light-client-db-worker";
-onerror = event => {
-    console.error(event);
-}
+import { parentPort as self } from "worker_threads";
+// onerror = event => {
+//     console.error(event);
+// }
 
-onmessage = async (evt) => {
-    const data = evt.data as DbWorkerInitializeOptions;
+self.on("message", async (evt) => {
+    const data = evt as DbWorkerInitializeOptions;
     wasmModule.set_shared_array(data.inputBuffer, data.outputBuffer);
     self.postMessage({});
     await wasmModule.main_loop(data.logLevel);
-}
+});
 
 export default {} as typeof Worker & { new(): Worker };

--- a/wasm/light-client-js/src/index.ts
+++ b/wasm/light-client-js/src/index.ts
@@ -76,12 +76,12 @@ class LightClient {
             networkConfigIsJSObject
         } as LightClientWorkerInitializeOptions);
         await new Promise<void>((res, rej) => {
-            this.dbWorker.onmessage = () => res();
-            this.dbWorker.onerror = (evt) => rej(evt);
+            this.dbWorker.on("message",() => res())  ;
+            this.dbWorker.on("error",(evt) => rej(evt));
         });
         await new Promise<void>((res, rej) => {
-            this.lightClientWorker.onmessage = () => res();
-            this.lightClientWorker.onerror = (evt) => rej(evt);
+            this.lightClientWorker.on("message",() => res());
+            this.lightClientWorker.on("error",(evt) => rej(evt));
         });
         (async () => {
             while (!this.stopping) {
@@ -119,14 +119,14 @@ class LightClient {
             });
             return await new Promise((resolve, reject) => {
                 const clean = () => {
-                    this.lightClientWorker.removeEventListener("message", resolveFn);
-                    this.lightClientWorker.removeEventListener("error", errorFn);
+                    this.lightClientWorker.removeListener("message", resolveFn);
+                    this.lightClientWorker.removeListener("error", errorFn);
                 }
-                const resolveFn = (evt: MessageEvent<{ ok: true; data: any } | { ok: false; error: string; }>) => {
-                    if (evt.data.ok === true) {
-                        resolve(evt.data.data);
+                const resolveFn = (evt: { ok: true; data: any } | { ok: false; error: string; }) => {
+                    if (evt.ok === true) {
+                        resolve(evt.data);
                     } else {
-                        reject(evt.data.error);
+                        reject(evt.error);
                     }
                     clean();
 
@@ -136,8 +136,8 @@ class LightClient {
                     clean();
 
                 };
-                this.lightClientWorker.addEventListener("message", resolveFn);
-                this.lightClientWorker.addEventListener("error", errorFn);
+                this.lightClientWorker.on("message", resolveFn);
+                this.lightClientWorker.on("error", errorFn);
             })
         })
 

--- a/wasm/light-client-js/src/lightclient.worker.ts
+++ b/wasm/light-client-js/src/lightclient.worker.ts
@@ -25,11 +25,11 @@ self.on("message", async (evt) => {
         loaded = true;
         return;
     }
-    const data = evt.data as LightClientFunctionCall;
+    const data = evt as LightClientFunctionCall;
     try {
         self.postMessage({
             ok: true,
-            data: ((wasmModule as any)[data.name])(...evt.data.args)
+            data: ((wasmModule as any)[data.name])(...evt.args)
         })
     } catch (e) {
         self.postMessage({

--- a/wasm/light-client-js/src/lightclient.worker.ts
+++ b/wasm/light-client-js/src/lightclient.worker.ts
@@ -1,12 +1,15 @@
 import { LightClientFunctionCall, LightClientWorkerInitializeOptions } from "./types";
 import wasmModule from "ckb-light-client-wasm";
-onerror = err => {
-    console.error(err);
-}
+import { parentPort as self } from "worker_threads";
+// onerror = err => {
+//     console.error(err);
+// }
 let loaded = false;
-onmessage = async (evt) => {
+// onmessage = ;
+
+self.on("message", async (evt) => {
     if (!loaded) {
-        const data = evt.data as LightClientWorkerInitializeOptions;
+        const data = evt as LightClientWorkerInitializeOptions;
         wasmModule.set_shared_array(data.inputBuffer, data.outputBuffer);
         if (data.networkConfigIsJSObject) {
             data.networkFlag.config = JSON.stringify(data.networkFlag.config);
@@ -35,6 +38,6 @@ onmessage = async (evt) => {
         })
         console.error(e);
     }
-};
+});
 
 export default {} as typeof Worker & { new(): Worker };

--- a/wasm/light-client-js/tsconfig.json
+++ b/wasm/light-client-js/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist/",
     "noImplicitAny": true,
     "module": "ESNext",
-    "target": "ESNext",
+    "target": "es2020",
     "allowJs": true,
     "mapRoot": "dist",
     "sourceMap": true,

--- a/wasm/light-client-wasm/index.mts
+++ b/wasm/light-client-wasm/index.mts
@@ -1,0 +1,11 @@
+import * as wasmModule from "./pkg/light-client-wasm.js";
+import wasm from "./pkg/light-client-wasm_bg.wasm";
+import "fake-indexeddb/auto"
+
+
+
+globalThis.indexedDB = indexedDB;
+
+wasmModule.initSync({ module: wasm });
+
+export default wasmModule;

--- a/wasm/light-client-wasm/index.ts
+++ b/wasm/light-client-wasm/index.ts
@@ -1,5 +1,0 @@
-import * as wasmModule from "./pkg/light-client-wasm";
-import wasm from "./pkg/light-client-wasm_bg.wasm";
-wasmModule.initSync({ module: wasm });
-
-export default wasmModule;

--- a/wasm/light-client-wasm/package.json
+++ b/wasm/light-client-wasm/package.json
@@ -16,5 +16,8 @@
         "webpack-cli": "^5.1.4"
     },
     "main": "dist/index.js",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "dependencies": {
+        "fake-indexeddb": "^6.2.5"
+    }
 }

--- a/wasm/light-client-wasm/tsconfig.json
+++ b/wasm/light-client-wasm/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "module": "es6",
+    "module": "nodenext",
     "target": "ES2015",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "sourceMap": true,
     "declaration": true,
     "declarationDir": "dist",

--- a/wasm/light-client-wasm/webpack.config.js
+++ b/wasm/light-client-wasm/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     plugins: [
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, "."),
-            outName: "light-client-db-worker",
+            outName: "light-client-wasm",
             extraArgs: "--target web"
         }),
         // new webpack.ProvidePlugin({

--- a/wasm/light-client-wasm/webpack.config.js
+++ b/wasm/light-client-wasm/webpack.config.js
@@ -2,8 +2,8 @@ const path = require('path');
 const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 const webpack = require("webpack");
 module.exports = {
-    entry: './index.ts',
-    target: "webworker",
+    entry: './index.mts',
+    target: "node",
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
@@ -16,12 +16,12 @@ module.exports = {
     plugins: [
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, "."),
-            outName: "light-client-wasm",
+            outName: "light-client-db-worker",
             extraArgs: "--target web"
         }),
-        new webpack.ProvidePlugin({
-            Buffer: ['buffer', 'Buffer'],
-        }),
+        // new webpack.ProvidePlugin({
+        //     Buffer: ['buffer', 'Buffer'],
+        // }),
     ],
     module: {
         rules: [
@@ -33,17 +33,20 @@ module.exports = {
                 test: /\.ts$/,
                 use: 'ts-loader',
                 exclude: /node_modules/,
-            }
+            },
         ]
-
     },
     experiments: {
         outputModule: true
     },
     mode: "production",
-    resolve: {
-        fallback: {
-            buffer: require.resolve('buffer/'),
-        },
+    // resolve: {
+    //     fallback: {
+    //         buffer: require.resolve('buffer/'),
+    //     },
+    // },
+    node: {
+        global: false,
+        __dirname: false
     },
 };


### PR DESCRIPTION
Support running light-client-wasm on nodejs, mainly includes:
- [ ] Handling Difference of Workers between browser and node
- [ ] Polyfilling IndexedDB
- [ ] Handling packing differences between browser and node
