### PR TITLE
add linux and macos arm64 release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,21 +34,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-15-intel, macos-14, windows-2022 ]
         include:
           - os: ubuntu-22.04
+            build_type: portable
             bin_suffix:
             pkg_suffix: x86_64-linux-portable
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
+            build_type: standard
             bin_suffix:
             pkg_suffix: x86_64-linux
+          - os: ubuntu-22.04-arm
+            build_type: portable
+            bin_suffix:
+            pkg_suffix: aarch64-linux-portable
+          - os: ubuntu-22.04-arm
+            build_type: standard
+            bin_suffix:
+            pkg_suffix: aarch64-linux
           - os: macos-15-intel
+            build_type: portable
             bin_suffix:
             pkg_suffix: x86_64-darwin-portable
-          - os: macos-14
+          - os: macos-15
+            build_type: standard
             bin_suffix:
-            pkg_suffix: x86_64-darwin
+            pkg_suffix: aarch64-darwin
           - os: windows-2022
+            build_type: standard
             bin_suffix: .exe
             pkg_suffix: x86_64-windows
     steps:
@@ -66,8 +78,8 @@ jobs:
         echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         scoop install llvm yasm
-    - if: matrix.os == 'ubuntu-22.04'
-      name: Build linux portable
+    - if: matrix.os == 'ubuntu-22.04' && matrix.build_type == 'portable'
+      name: Build linux portable (x86_64)
       run: |
         export PWD_DIR=$(pwd)
         curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
@@ -80,21 +92,38 @@ jobs:
         export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
         export OPENSSL_STATIC=1
         cargo build --release --features portable
-    - if: matrix.os == 'ubuntu-24.04'
-      name: Build linux
+    - if: matrix.os == 'ubuntu-22.04' && matrix.build_type == 'standard'
+      name: Build linux (x86_64)
       run: cargo build --release
-    - if: matrix.os == 'macos-15-intel'
-      name: Build macos portable
+    - if: matrix.os == 'ubuntu-22.04-arm' && matrix.build_type == 'portable'
+      name: Build linux portable (aarch64)
+      run: |
+        export PWD_DIR=$(pwd)
+        curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
+        tar -xzf openssl-1.1.1s.tar.gz
+        cd openssl-1.1.1s
+        ./Configure linux-aarch64 shared
+        make
+        cd ..
+        export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
+        export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
+        export OPENSSL_STATIC=1
+        cargo build --release --features portable
+    - if: matrix.os == 'ubuntu-22.04-arm' && matrix.build_type == 'standard'
+      name: Build linux (aarch64)
+      run: cargo build --release
+    - if: matrix.os == 'macos-15-intel' && matrix.build_type == 'portable'
+      name: Build macos portable (x86_64)
       run: |
         export OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib
         export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include
         export OPENSSL_STATIC=1
         cargo build --release --features portable
-    - if: matrix.os == 'macos-14'
-      name: Build macos
+    - if: matrix.os == 'macos-15' && matrix.build_type == 'standard'
+      name: Build macos (aarch64)
       run: |
-        export OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib
-        export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include
+        export OPENSSL_LIB_DIR=/opt/homebrew/opt/openssl@1.1/lib
+        export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@1.1/include
         export OPENSSL_STATIC=1
         cargo build --release
     - if: matrix.os == 'windows-2022'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,45 +80,19 @@ jobs:
         scoop install llvm yasm
     - if: matrix.os == 'ubuntu-22.04' && matrix.build_type == 'portable'
       name: Build linux portable (x86_64)
-      run: |
-        export PWD_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-        tar -xzf openssl-1.1.1s.tar.gz
-        cd openssl-1.1.1s
-        ./Configure linux-x86_64 shared
-        make
-        cd ..
-        export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
-        export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
-        export OPENSSL_STATIC=1
-        cargo build --release --features portable
+      run: cargo build --release --features portable,vendored-openssl
     - if: matrix.os == 'ubuntu-22.04' && matrix.build_type == 'standard'
       name: Build linux (x86_64)
       run: cargo build --release
     - if: matrix.os == 'ubuntu-22.04-arm' && matrix.build_type == 'portable'
       name: Build linux portable (aarch64)
-      run: |
-        export PWD_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-        tar -xzf openssl-1.1.1s.tar.gz
-        cd openssl-1.1.1s
-        ./Configure linux-aarch64 shared
-        make
-        cd ..
-        export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
-        export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
-        export OPENSSL_STATIC=1
-        cargo build --release --features portable
+      run: cargo build --release --features portable,vendored-openssl
     - if: matrix.os == 'ubuntu-22.04-arm' && matrix.build_type == 'standard'
       name: Build linux (aarch64)
       run: cargo build --release
     - if: matrix.os == 'macos-15-intel' && matrix.build_type == 'portable'
       name: Build macos portable (x86_64)
-      run: |
-        export OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib
-        export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include
-        export OPENSSL_STATIC=1
-        cargo build --release --features portable
+      run: cargo build --release --features portable,vendored-openssl
     - if: matrix.os == 'macos-15' && matrix.build_type == 'standard'
       name: Build macos (aarch64)
       run: |
@@ -126,7 +100,7 @@ jobs:
         export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl@1.1/include
         export OPENSSL_STATIC=1
         cargo build --release
-    - if: matrix.os == 'windows-2022'
+    - if: matrix.os == 'windows-2022' && matrix.build_type == 'standard'
       name: Build windows
       run: cargo build --release
     - name: Get the Version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "jsonrpc-http-server",
  "jsonrpc-server-utils",
  "log",
+ "openssl",
  "rand 0.8.5",
  "serde_json",
  "tempfile",

--- a/light-client-bin/Cargo.toml
+++ b/light-client-bin/Cargo.toml
@@ -32,6 +32,7 @@ rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
 ], default-features = false, optional = true }
 env_logger = "0.11"
 anyhow = "1.0.56"
+openssl = { version = "0.10", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"
@@ -51,6 +52,7 @@ portable = ["rocksdb", "rocksdb/portable", "ckb-light-client-lib/rocksdb"]
 march-native = ["rocksdb", "rocksdb/march-native", "ckb-light-client-lib/rocksdb"]
 sqlite = ["ckb-light-client-lib/sqlite"]
 rocksdb = ["dep:rocksdb"]
+vendored-openssl = ["openssl/vendored"]
 
 # [profile.release]
 # overflow-checks = true


### PR DESCRIPTION
This PR want to add arm64 build for Ubuntu and MacOS

Release Build Matrix:

  Linux (Ubuntu 22.04):
  - x86_64-linux-portable - Portable build with static OpenSSL
  - x86_64-linux - Standard build with system libraries
  - aarch64-linux-portable - ARM64 portable build with static OpenSSL
  - aarch64-linux - ARM64 standard build with system libraries

  macOS:
  - x86_64-darwin-portable - Intel portable build (macos-15-intel)
  - aarch64-darwin - Apple Silicon standard build (macos-15)

  Windows:
  - x86_64-windows - Standard build
