### PR TITLE
fix: prevent overflow in update_latest_block_filter_hashes (GHSA-3f5f)

### DIFF
--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -687,18 +687,32 @@ impl LatestBlockFilterHashes {
             );
             return Err(StatusCode::Ignore.with_context(errmsg));
         }
-        let mut end_number = start_number + block_filter_hashes.len() as BlockNumber - 1;
-        if finalized_check_point_number >= end_number {
-            let errmsg = format!(
-                "finalized check point ({}) is not less than end number ({})",
-                finalized_check_point_number, end_number,
-            );
-            return Err(StatusCode::Ignore.with_context(errmsg));
-        }
         if start_number > last_proved_number {
             let errmsg = format!(
                 "start number ({}) is greater than the proved number ({})",
                 start_number, last_proved_number
+            );
+            return Err(StatusCode::Ignore.with_context(errmsg));
+        }
+        let mut end_number = match block_filter_hashes
+            .len()
+            .checked_add(start_number as usize)
+            .and_then(|v| v.checked_sub(1))
+        {
+            Some(v) => v as BlockNumber,
+            None => {
+                let errmsg = format!(
+                    "overflow computing end number: start_number ({}) + len ({}) - 1",
+                    start_number,
+                    block_filter_hashes.len()
+                );
+                return Err(StatusCode::Ignore.with_context(errmsg));
+            }
+        };
+        if finalized_check_point_number >= end_number {
+            let errmsg = format!(
+                "finalized check point ({}) is not less than end number ({})",
+                finalized_check_point_number, end_number,
             );
             return Err(StatusCode::Ignore.with_context(errmsg));
         }


### PR DESCRIPTION
## Summary

Fixes GHSA-3f5f-x2vp-3rh8: LatestBlockFilterHashes update can overflow on peer-controlled start_number

## Root Cause

In `LatestBlockFilterHashes::update_latest_block_filter_hashes()`, the code computed `end_number = start_number + block_filter_hashes.len() - 1` before validating that `start_number` was within bounds. A malicious peer could supply `start_number = u64::MAX` and one filter hash, causing integer overflow panic in release builds.

## Fix

1. Moved the `start_number > last_proved_number` guard before the end-number arithmetic
2. Replaced unchecked addition/subtraction with `checked_add` and `checked_sub` to safely compute end number from peer-controlled values