### PR TITLE
fix: use checked_add for peer-supplied block number continuity check (GHSA-4485)

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -776,7 +776,7 @@ pub(crate) fn check_if_response_is_matched(
             let last_last_n_header_number = headers[headers.len() - 1].header().number();
             let last_number = last_header.header().number();
             if first_last_n_header_number != start_number
-                || last_last_n_header_number + 1 != last_number
+                || last_last_n_header_number.checked_add(1) != Some(last_number)
             {
                 let errmsg = format!(
                 "there should be all blocks of [{}, {}) since no sampled blocks, but got [{}, {}]",


### PR DESCRIPTION
## Summary

Fixes GHSA-4485-f47v-8935: Malformed proof headers can panic on u64 overflow

## Root Cause

In `check_if_response_is_matched()`, the `sampled_count == 0` branch checks header continuity with `last_last_n_header_number + 1 != last_number`. The `last_last_n_header_number` comes from a peer-supplied header vector before cryptographic validation. A malicious peer can send a header with number `u64::MAX`, causing integer overflow panic.

## Fix

Replace unchecked `+ 1` with `checked_add(1)`. When overflow occurs (returning `None`), the continuity check naturally fails and the message is treated as malformed protocol data.