### PR TITLE
fix: validate reorg_count before subtraction to prevent panic (GHSA-2xpj)

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -761,6 +761,13 @@ pub(crate) fn check_if_response_is_matched(
             .count();
         let last_n_count = total_count - before_boundary_count;
         if last_n_count > last_n_blocks {
+            if before_boundary_count < reorg_count {
+                let errmsg = format!(
+                    "inconsistent proof data: reorg_count ({}) > before_boundary_count ({})",
+                    reorg_count, before_boundary_count
+                );
+                return Err(StatusCode::MalformedProtocolMessage.with_context(errmsg));
+            }
             (before_boundary_count - reorg_count, last_n_count)
         } else {
             (total_count - reorg_count - last_n_blocks, last_n_blocks)


### PR DESCRIPTION
## Summary

Fixes GHSA-2xpj-746v-x388: Unchecked reorg subtraction can panic on P2P proof

## Root Cause

In `check_if_response_is_matched()`, the code computes `before_boundary_count - reorg_count` without verifying that `before_boundary_count >= reorg_count`. A malicious peer can craft headers where all peer-controlled total-difficulty values are above the local difficulty boundary, making `before_boundary_count` smaller than `reorg_count`, causing integer underflow panic.

## Fix

Add a validation check before the subtraction: if `before_boundary_count < reorg_count`, return a `MalformedProtocolMessage` error for inconsistent peer-supplied proof data instead of panicking.