### PR TITLE
fix: reject start_number beyond last_header to prevent underflow (GHSA-mvf7)

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -717,6 +717,17 @@ pub(crate) fn check_if_response_is_matched(
     let total_count = headers.len();
 
     let start_number: BlockNumber = prev_request.start_number().unpack();
+    let last_number = last_header.header().number();
+
+    // Reject if start_number is beyond the last header.
+    if start_number > last_number {
+        let errmsg = format!(
+            "start_number ({}) is greater than last_header number ({})",
+            start_number, last_number
+        );
+        return Err(StatusCode::MalformedProtocolMessage.with_context(errmsg));
+    }
+
     let reorg_count = headers
         .iter()
         .take_while(|h| h.header().number() < start_number)


### PR DESCRIPTION
## Summary

Fixes GHSA-mvf7-9h5m-m4wp: Light-client GetLastStateProof with start_number beyond last_hash can panic the protocol handler

## Root Cause

The light-client protocol validates that `last_hash` is on the main chain, but does not reject a `GetLastStateProof` request whose `start_number` is greater than the block number of `last_hash`. Range arithmetic computing `last_block_number - start_block_number` can underflow in checked-overflow release builds.

## Fix

Add early validation in `check_if_response_is_matched()` that rejects the request/response if `start_number > last_header_number`, returning `MalformedProtocolMessage` error before any range arithmetic is performed.