### PR TITLE
fix: reject genesis last_header in verify_mmr_proof to prevent subtraction panic (GHSA-5jvv)

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -1122,6 +1122,10 @@ pub(crate) fn verify_mmr_proof<'a, T: Iterator<Item = &'a HeaderView>>(
         );
         return Err(StatusCode::InvalidProof.with_context(errmsg));
     };
+    if last_header.header().is_genesis() {
+        let errmsg = "last_header is genesis, which has no parent chain root to verify against";
+        return Err(StatusCode::InvalidParentBlock.with_context(errmsg));
+    }
     let parent_chain_root = last_header.parent_chain_root();
     let proof: MMRProof = {
         let mmr_size = leaf_index_to_mmr_size(parent_chain_root.end_number().unpack());
@@ -1146,7 +1150,7 @@ pub(crate) fn verify_mmr_proof<'a, T: Iterator<Item = &'a HeaderView>>(
             Ok(tmp) => tmp,
             Err(err) => {
                 let errmsg = format!("failed to verify all digest since {}", err);
-                return Err(StatusCode::InvalidProof.with_context(errmsg));
+                return Err(StatusCode::InvalidParentBlock.with_context(errmsg));
             }
         }
     };


### PR DESCRIPTION
## Summary

Fixes GHSA-5jvv-gpgv-mf3f: Light client proof request with genesis last_hash can panic proof generation

## Root Cause

Proof verification calls `last_header.parent_chain_root()` which for the genesis block (block 0) computes the parent chain root of a nonexistent parent. This can lead to arithmetic equivalent to `last_block.number() - 1` which underflows in checked-overflow release builds, causing a panic.

## Fix

Add an early check in `verify_mmr_proof()` to reject genesis as the `last_header`, since genesis has no parent chain root to verify against. Returns `InvalidProof` error instead of panicking.