### PR TITLE
Use checked arithmetic in block filter processing

### DIFF
--- a/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
@@ -142,10 +142,31 @@ impl<'a> BlockFilterHashesProcess<'a> {
                     return StatusCode::Ignore.with_context(errmsg);
                 }
             };
-            let end_number = start_number + block_filter_hashes.len() as BlockNumber - 1;
+            let Some(end_number) = start_number
+                .checked_add(block_filter_hashes.len() as BlockNumber)
+                .and_then(|n| n.checked_sub(1))
+            else {
+                let errmsg = format!(
+                    "overflow computing end_number: start_number={}, len={}",
+                    start_number,
+                    block_filter_hashes.len()
+                );
+                return StatusCode::Ignore.with_context(errmsg);
+            };
             if end_number > next_cached_check_point_number {
                 let diff = end_number - next_cached_check_point_number;
-                let index = block_filter_hashes.len() - (diff as usize) - 1;
+                let Some(index) = block_filter_hashes
+                    .len()
+                    .checked_sub(diff as usize)
+                    .and_then(|n| n.checked_sub(1))
+                else {
+                    let errmsg = format!(
+                        "underflow computing block filter hash index: \
+                         len={}, diff={diff}",
+                        block_filter_hashes.len(),
+                    );
+                    return StatusCode::Ignore.with_context(errmsg);
+                };
                 let new_hash = &block_filter_hashes[index];
                 if next_cached_check_point != *new_hash {
                     let errmsg = format!(

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -70,7 +70,14 @@ impl<'a> BlockFiltersProcess<'a> {
 
         let min_filtered_block_number = self.filter.storage.get_min_filtered_block_number();
         debug!("current min filtered block number: {min_filtered_block_number}");
-        if min_filtered_block_number + 1 != start_number {
+        let Some(expected_start_number) = min_filtered_block_number.checked_add(1) else {
+            info!(
+                "ignoring, min_filtered_block_number overflow: {}",
+                min_filtered_block_number
+            );
+            return Status::ok();
+        };
+        if expected_start_number != start_number {
             info!(
                 "ignoring, the start_number of block_filters message {} is not continuous with min_filtered_block_number: {}",
                 start_number,
@@ -216,7 +223,16 @@ impl<'a> BlockFiltersProcess<'a> {
         );
         let actual_blocks_count = blocks_count.min(limit);
         let tip_header = self.filter.storage.get_tip_header();
-        let filtered_block_number = start_number - 1 + actual_blocks_count as BlockNumber;
+        let Some(filtered_block_number) = start_number
+            .checked_sub(1)
+            .and_then(|n| n.checked_add(actual_blocks_count as BlockNumber))
+        else {
+            let errmsg = format!(
+                "overflow computing filtered_block_number: \
+                 start_number={start_number}, actual_blocks_count={actual_blocks_count}"
+            );
+            return StatusCode::Ignore.with_context(errmsg);
+        };
 
         if possible_match_blocks_len != 0 {
             let blocks = possible_match_blocks


### PR DESCRIPTION
Replace raw integer arithmetic with checked operations in `block_filters_process` and `block_filter_hashes_process` to improve robustness when handling malformed peer messages.