### PR TITLE
Add bounds checks before indexing block filter hashes

### DIFF
--- a/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filter_hashes_process.rs
@@ -131,7 +131,13 @@ impl<'a> BlockFilterHashesProcess<'a> {
                 // This branch must be satisfied `start_number > cached_check_point_number + 1`.
                 let diff = start_number - cached_check_point_number;
                 let index = diff as usize - 2;
-                let cached_hash = &cached_hashes[index];
+                let Some(cached_hash) = cached_hashes.get(index) else {
+                    let errmsg = format!(
+                        "cached hash index {index} out of bounds, len: {}",
+                        cached_hashes.len()
+                    );
+                    return StatusCode::Ignore.with_context(errmsg);
+                };
                 if *cached_hash != parent_block_filter_hash {
                     let errmsg = format!(
                         "cached hash for block {} is {:#x} but parent hash is {:#x}",
@@ -156,6 +162,13 @@ impl<'a> BlockFilterHashesProcess<'a> {
                 }
             }
             let index_offset = (start_number - (cached_check_point_number + 1)) as usize;
+            if index_offset > cached_hashes.len() {
+                let errmsg = format!(
+                    "cached hash offset {index_offset} out of bounds, len: {}",
+                    cached_hashes.len()
+                );
+                return StatusCode::Ignore.with_context(errmsg);
+            }
             for (index, (old_hash, new_hash)) in cached_hashes[index_offset..]
                 .iter()
                 .zip(block_filter_hashes.iter())

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -757,7 +757,13 @@ impl LatestBlockFilterHashes {
         } else {
             let diff = start_number - finalized_check_point_number;
             let index = diff as usize - 2;
-            let filter_hash = &self.inner[index];
+            let Some(filter_hash) = self.inner.get(index) else {
+                let errmsg = format!(
+                    "filter hash index {index} out of bounds, inner len: {}",
+                    self.inner.len()
+                );
+                return Err(StatusCode::Ignore.with_context(errmsg));
+            };
             if filter_hash != parent_block_filter_hash {
                 let errmsg = format!(
                     "filter hash for block {} is {:#x} but parent hash is {:#}",


### PR DESCRIPTION
Add explicit bounds checks before indexing into block filter hash vectors in `block_filter_hashes_process` and `update_latest_block_filter_hashes`, using `.get()` instead of direct indexing to avoid panics on malformed messages.