### PR TITLE
Fix relayer extract_peer_id unwrap and add bounds check in block filter processing

### DIFF
--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -152,6 +152,14 @@ impl<'a> BlockFiltersProcess<'a> {
                     (cached_check_point, cached_block_filter_hashes)
                 } else {
                     let start_index = (start_number - cached_check_point_number) as usize - 2;
+                    if start_index >= cached_block_filter_hashes.len() {
+                        let errmsg = format!(
+                            "cached block filter hashes index {start_index} out of bounds, \
+                             len: {}",
+                            cached_block_filter_hashes.len()
+                        );
+                        return StatusCode::Ignore.with_context(errmsg);
+                    }
                     let parent_hash = cached_block_filter_hashes[start_index].clone();
                     cached_block_filter_hashes.drain(..=start_index);
                     (parent_hash, cached_block_filter_hashes)

--- a/light-client-lib/src/protocols/relayer.rs
+++ b/light-client-lib/src/protocols/relayer.rs
@@ -141,10 +141,13 @@ impl CKBProtocolHandler for RelayProtocol {
         let flag = read_lock!(self.pending_txs).is_not_empty_and_updated_at(60);
 
         if flag {
-            let peer_id = nc
+            let Some(peer_id) = nc
                 .get_peer(peer)
                 .and_then(|p| extract_peer_id(&p.connected_addr))
-                .unwrap();
+            else {
+                warn!("RelayProtocol failed to extract peer_id for peer={}", peer);
+                return;
+            };
             let tx_hashes =
                 write_lock!(self.pending_txs).fetch_transaction_hashes_for_broadcast(peer_id);
             if !tx_hashes.is_empty() {


### PR DESCRIPTION
- Replace `.unwrap()` on `extract_peer_id` with `let Some(...) else` in relay protocol connected handler to avoid panic when peer address format is unexpected
- Add bounds check before indexing into `cached_block_filter_hashes` in block filters processing