### PR TITLE
Guard against oob range when reorg_count equals headers length

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -254,6 +254,7 @@ impl<'a> SendLastStateProofProcess<'a> {
                     } else if reorg_count == 0 {
                         new_last_headers
                     } else if sampled_count == 0
+                        && reorg_count < headers.len()
                         && check_continuous_headers(&headers[(reorg_count - 1)..=reorg_count])
                             .is_ok()
                     {


### PR DESCRIPTION
Add `reorg_count < headers.len()` guard before constructing the inclusive range `(reorg_count - 1)..=reorg_count` to avoid out-of-bounds access when all headers are reorg headers.