### PR TITLE
Validate v1 message field lengths and handle missing check points

### DIFF
--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -149,9 +149,9 @@ impl<'a> BlockFiltersProcess<'a> {
                         .first()
                         .cloned()
                     else {
-                        let errmsg =
+                        let error_message =
                             format!("check point at index {cached_check_point_index} is missing");
-                        return StatusCode::CheckPointsIsUnexpected.with_context(errmsg);
+                        return StatusCode::InternalError.with_context(error_message);
                     };
                     (cached_check_point, cached_block_filter_hashes)
                 } else {

--- a/light-client-lib/src/protocols/filter/components/block_filters_process.rs
+++ b/light-client-lib/src/protocols/filter/components/block_filters_process.rs
@@ -142,13 +142,17 @@ impl<'a> BlockFiltersProcess<'a> {
                     return StatusCode::Ignore.with_context(errmsg);
                 }
                 if start_number == cached_check_point_number + 1 {
-                    let cached_check_point = self
+                    let Some(cached_check_point) = self
                         .filter
                         .storage
                         .get_check_points(cached_check_point_index, 1)
                         .first()
                         .cloned()
-                        .expect("all check points before finalized should be existed");
+                    else {
+                        let errmsg =
+                            format!("check point at index {cached_check_point_index} is missing");
+                        return StatusCode::CheckPointsIsUnexpected.with_context(errmsg);
+                    };
                     (cached_check_point, cached_block_filter_hashes)
                 } else {
                     let start_index = (start_number - cached_check_point_number) as usize - 2;

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -137,6 +137,17 @@ impl<'a> SendBlocksProofProcess<'a> {
                     .map(|extension| extension.to_entity().to_opt())
                     .collect();
 
+                if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+                    let errmsg = format!(
+                        "SendBlocksProof v1 field length mismatch: \
+                         headers={}, uncle_hashes={}, extensions={}",
+                        headers.len(),
+                        uncle_hashes.len(),
+                        extensions.len()
+                    );
+                    return StatusCode::MalformedProtocolMessage.with_context(errmsg);
+                }
+
                 return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
                 extensions
             } else {

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -58,22 +58,32 @@ impl<'a> SendBlocksProofProcess<'a> {
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
         let headers_len = self.message.headers().len();
-        let is_v1 = self.message.count_extra_fields() >= 2;
-        if is_v1 {
-            let message_v1 =
-                packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
-            let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
-            let extensions_len = message_v1.blocks_extension().len();
-
-            if uncle_hashes_len != headers_len || extensions_len != headers_len {
-                let error_message = format!(
-                    "SendBlocksProof v1 field length mismatch: \
-                     headers={}, uncle_hashes={}, extensions={}",
-                    headers_len, uncle_hashes_len, extensions_len
-                );
-                return StatusCode::MalformedProtocolMessage.with_context(error_message);
+        // Parse the V1 extra fields with a verifying reader up front, before any
+        // early return, so that all later access is over validated bytes and can
+        // never panic on malformed/unchecked input.
+        let message_v1 = if self.message.count_extra_fields() >= 2 {
+            match packed::SendBlocksProofV1Reader::from_compatible_slice(self.message.as_slice()) {
+                Ok(message_v1) => {
+                    let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
+                    let extensions_len = message_v1.blocks_extension().len();
+                    if uncle_hashes_len != headers_len || extensions_len != headers_len {
+                        let error_message = format!(
+                            "SendBlocksProof v1 field length mismatch: \
+                             headers={}, uncle_hashes={}, extensions={}",
+                            headers_len, uncle_hashes_len, extensions_len
+                        );
+                        return StatusCode::MalformedProtocolMessage.with_context(error_message);
+                    }
+                    Some(message_v1)
+                }
+                Err(_) => {
+                    return StatusCode::MalformedProtocolMessage
+                        .with_context("SendBlocksProof v1 extra fields are malformed");
+                }
             }
-        }
+        } else {
+            None
+        };
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
@@ -138,9 +148,7 @@ impl<'a> SendBlocksProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            let extensions = if is_v1 {
-                let message_v1 =
-                    packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
+            let extensions = if let Some(message_v1) = message_v1 {
                 let uncle_hashes: Vec<_> = message_v1
                     .blocks_uncles_hash()
                     .iter()

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -57,49 +57,28 @@ impl<'a> SendBlocksProofProcess<'a> {
         };
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
-        let headers: Vec<_> = self
-            .message
-            .headers()
-            .iter()
-            .map(|header| header.to_entity().into_view())
-            .collect();
-
+        let headers_len = self.message.headers().len();
         let is_v1 = self.message.count_extra_fields() >= 2;
-        let (uncle_hashes, extensions) = if is_v1 {
+        if is_v1 {
             let message_v1 =
                 packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
-            let uncle_hashes: Vec<_> = message_v1
-                .blocks_uncles_hash()
-                .iter()
-                .map(|uncle_hashes| uncle_hashes.to_entity())
-                .collect();
+            let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
+            let extensions_len = message_v1.blocks_extension().len();
 
-            let extensions: Vec<_> = message_v1
-                .blocks_extension()
-                .iter()
-                .map(|extension| extension.to_entity().to_opt())
-                .collect();
-
-            if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+            if uncle_hashes_len != headers_len || extensions_len != headers_len {
                 let error_message = format!(
                     "SendBlocksProof v1 field length mismatch: \
                      headers={}, uncle_hashes={}, extensions={}",
-                    headers.len(),
-                    uncle_hashes.len(),
-                    extensions.len()
+                    headers_len, uncle_hashes_len, extensions_len
                 );
                 return StatusCode::MalformedProtocolMessage.with_context(error_message);
             }
-
-            (Some(uncle_hashes), extensions)
-        } else {
-            (None, vec![None; headers.len()])
-        };
+        }
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
             if self.message.proof().is_empty()
-                && headers.is_empty()
+                && self.message.headers().is_empty()
                 && self.message.missing_block_hashes().is_empty()
             {
                 return_if_failed!(self
@@ -118,6 +97,13 @@ impl<'a> SendBlocksProofProcess<'a> {
                 return StatusCode::UnexpectedResponse.into();
             }
         }
+
+        let headers: Vec<_> = self
+            .message
+            .headers()
+            .iter()
+            .map(|header| header.to_entity().into_view())
+            .collect();
 
         // Check if the response is match the request.
         let received_block_hashes = headers
@@ -152,9 +138,25 @@ impl<'a> SendBlocksProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            if let Some(uncle_hashes) = uncle_hashes.as_ref() {
-                return_if_failed!(verify_extra_hash(&headers, uncle_hashes, &extensions));
-            }
+            let extensions = if is_v1 {
+                let message_v1 =
+                    packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
+                let uncle_hashes: Vec<_> = message_v1
+                    .blocks_uncles_hash()
+                    .iter()
+                    .map(|uncle_hashes| uncle_hashes.to_entity())
+                    .collect();
+                let extensions: Vec<_> = message_v1
+                    .blocks_extension()
+                    .iter()
+                    .map(|extension| extension.to_entity().to_opt())
+                    .collect();
+
+                return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
+                extensions
+            } else {
+                vec![None; headers.len()]
+            };
 
             // Verify the proof
             return_if_failed!(verify_mmr_proof(

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -57,11 +57,49 @@ impl<'a> SendBlocksProofProcess<'a> {
         };
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
+        let headers: Vec<_> = self
+            .message
+            .headers()
+            .iter()
+            .map(|header| header.to_entity().into_view())
+            .collect();
+
+        let is_v1 = self.message.count_extra_fields() >= 2;
+        let (uncle_hashes, extensions) = if is_v1 {
+            let message_v1 =
+                packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
+            let uncle_hashes: Vec<_> = message_v1
+                .blocks_uncles_hash()
+                .iter()
+                .map(|uncle_hashes| uncle_hashes.to_entity())
+                .collect();
+
+            let extensions: Vec<_> = message_v1
+                .blocks_extension()
+                .iter()
+                .map(|extension| extension.to_entity().to_opt())
+                .collect();
+
+            if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+                let error_message = format!(
+                    "SendBlocksProof v1 field length mismatch: \
+                     headers={}, uncle_hashes={}, extensions={}",
+                    headers.len(),
+                    uncle_hashes.len(),
+                    extensions.len()
+                );
+                return StatusCode::MalformedProtocolMessage.with_context(error_message);
+            }
+
+            (Some(uncle_hashes), extensions)
+        } else {
+            (None, vec![None; headers.len()])
+        };
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
             if self.message.proof().is_empty()
-                && self.message.headers().is_empty()
+                && headers.is_empty()
                 && self.message.missing_block_hashes().is_empty()
             {
                 return_if_failed!(self
@@ -80,13 +118,6 @@ impl<'a> SendBlocksProofProcess<'a> {
                 return StatusCode::UnexpectedResponse.into();
             }
         }
-
-        let headers: Vec<_> = self
-            .message
-            .headers()
-            .iter()
-            .map(|header| header.to_entity().into_view())
-            .collect();
 
         // Check if the response is match the request.
         let received_block_hashes = headers
@@ -108,7 +139,7 @@ impl<'a> SendBlocksProofProcess<'a> {
         }
 
         // If all blocks are missing.
-        if self.message.headers().is_empty() {
+        if headers.is_empty() {
             if !self.message.proof().is_empty() {
                 error!(
                     "peer {} send a proof when all blocks are missing",
@@ -121,38 +152,9 @@ impl<'a> SendBlocksProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            let is_v1 = self.message.count_extra_fields() >= 2;
-            let extensions = if is_v1 {
-                let message_v1 =
-                    packed::SendBlocksProofV1Reader::new_unchecked(self.message.as_slice());
-                let uncle_hashes: Vec<_> = message_v1
-                    .blocks_uncles_hash()
-                    .iter()
-                    .map(|uncle_hashes| uncle_hashes.to_entity())
-                    .collect();
-
-                let extensions: Vec<_> = message_v1
-                    .blocks_extension()
-                    .iter()
-                    .map(|extension| extension.to_entity().to_opt())
-                    .collect();
-
-                if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
-                    let errmsg = format!(
-                        "SendBlocksProof v1 field length mismatch: \
-                         headers={}, uncle_hashes={}, extensions={}",
-                        headers.len(),
-                        uncle_hashes.len(),
-                        extensions.len()
-                    );
-                    return StatusCode::MalformedProtocolMessage.with_context(errmsg);
-                }
-
-                return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
-                extensions
-            } else {
-                vec![None; headers.len()]
-            };
+            if let Some(uncle_hashes) = uncle_hashes.as_ref() {
+                return_if_failed!(verify_extra_hash(&headers, uncle_hashes, &extensions));
+            }
 
             // Verify the proof
             return_if_failed!(verify_mmr_proof(

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -58,22 +58,36 @@ impl<'a> SendTransactionsProofProcess<'a> {
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
         let filtered_blocks_len = self.message.filtered_blocks().len();
-        let is_v1 = self.message.count_extra_fields() >= 2;
-        if is_v1 {
-            let message_v1 =
-                packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
-            let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
-            let extensions_len = message_v1.blocks_extension().len();
-
-            if uncle_hashes_len != filtered_blocks_len || extensions_len != filtered_blocks_len {
-                let error_message = format!(
-                    "SendTransactionsProof v1 field length mismatch: \
-                     filtered_blocks={}, uncle_hashes={}, extensions={}",
-                    filtered_blocks_len, uncle_hashes_len, extensions_len
-                );
-                return StatusCode::MalformedProtocolMessage.with_context(error_message);
+        // Parse the V1 extra fields with a verifying reader up front, before any
+        // early return, so that all later access is over validated bytes and can
+        // never panic on malformed/unchecked input.
+        let message_v1 = if self.message.count_extra_fields() >= 2 {
+            match packed::SendTransactionsProofV1Reader::from_compatible_slice(
+                self.message.as_slice(),
+            ) {
+                Ok(message_v1) => {
+                    let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
+                    let extensions_len = message_v1.blocks_extension().len();
+                    if uncle_hashes_len != filtered_blocks_len
+                        || extensions_len != filtered_blocks_len
+                    {
+                        let error_message = format!(
+                            "SendTransactionsProof v1 field length mismatch: \
+                             filtered_blocks={}, uncle_hashes={}, extensions={}",
+                            filtered_blocks_len, uncle_hashes_len, extensions_len
+                        );
+                        return StatusCode::MalformedProtocolMessage.with_context(error_message);
+                    }
+                    Some(message_v1)
+                }
+                Err(_) => {
+                    return StatusCode::MalformedProtocolMessage
+                        .with_context("SendTransactionsProof v1 extra fields are malformed");
+                }
             }
-        }
+        } else {
+            None
+        };
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
@@ -139,9 +153,7 @@ impl<'a> SendTransactionsProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            let extensions = if is_v1 {
-                let message_v1 =
-                    packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
+            let extensions = if let Some(message_v1) = message_v1 {
                 let uncle_hashes: Vec<_> = message_v1
                     .blocks_uncles_hash()
                     .iter()

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -57,11 +57,53 @@ impl<'a> SendTransactionsProofProcess<'a> {
         };
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
+        let filtered_blocks: Vec<packed::FilteredBlock> = self
+            .message
+            .filtered_blocks()
+            .to_entity()
+            .into_iter()
+            .collect();
+        let headers: Vec<_> = filtered_blocks
+            .iter()
+            .map(|block| block.header().into_view())
+            .collect();
+
+        let is_v1 = self.message.count_extra_fields() >= 2;
+        let (uncle_hashes, extensions) = if is_v1 {
+            let message_v1 =
+                packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
+            let uncle_hashes: Vec<_> = message_v1
+                .blocks_uncles_hash()
+                .iter()
+                .map(|uncle_hashes| uncle_hashes.to_entity())
+                .collect();
+
+            let extensions: Vec<_> = message_v1
+                .blocks_extension()
+                .iter()
+                .map(|extension| extension.to_entity().to_opt())
+                .collect();
+
+            if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+                let error_message = format!(
+                    "SendTransactionsProof v1 field length mismatch: \
+                     headers={}, uncle_hashes={}, extensions={}",
+                    headers.len(),
+                    uncle_hashes.len(),
+                    extensions.len()
+                );
+                return StatusCode::MalformedProtocolMessage.with_context(error_message);
+            }
+
+            (Some(uncle_hashes), extensions)
+        } else {
+            (None, vec![None; headers.len()])
+        };
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
             if self.message.proof().is_empty()
-                && self.message.filtered_blocks().is_empty()
+                && filtered_blocks.is_empty()
                 && self.message.missing_tx_hashes().is_empty()
             {
                 return_if_failed!(self
@@ -81,17 +123,6 @@ impl<'a> SendTransactionsProofProcess<'a> {
             }
         }
 
-        let filtered_blocks: Vec<packed::FilteredBlock> = self
-            .message
-            .filtered_blocks()
-            .to_entity()
-            .into_iter()
-            .collect();
-        let headers: Vec<_> = filtered_blocks
-            .iter()
-            .map(|block| block.header().into_view())
-            .collect();
-
         // Check if the response is match the request.
         let received_tx_hashes = filtered_blocks
             .iter()
@@ -109,7 +140,7 @@ impl<'a> SendTransactionsProofProcess<'a> {
         }
 
         // If all transactions are missing.
-        if self.message.filtered_blocks().is_empty() {
+        if filtered_blocks.is_empty() {
             if !self.message.proof().is_empty() {
                 error!(
                     "peer {} send a proof when all transactions are missing",
@@ -122,38 +153,9 @@ impl<'a> SendTransactionsProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            let is_v1 = self.message.count_extra_fields() >= 2;
-            let extensions = if is_v1 {
-                let message_v1 =
-                    packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
-                let uncle_hashes: Vec<_> = message_v1
-                    .blocks_uncles_hash()
-                    .iter()
-                    .map(|uncle_hashes| uncle_hashes.to_entity())
-                    .collect();
-
-                let extensions: Vec<_> = message_v1
-                    .blocks_extension()
-                    .iter()
-                    .map(|extension| extension.to_entity().to_opt())
-                    .collect();
-
-                if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
-                    let errmsg = format!(
-                        "SendTransactionsProof v1 field length mismatch: \
-                         headers={}, uncle_hashes={}, extensions={}",
-                        headers.len(),
-                        uncle_hashes.len(),
-                        extensions.len()
-                    );
-                    return StatusCode::MalformedProtocolMessage.with_context(errmsg);
-                }
-
-                return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
-                extensions
-            } else {
-                vec![None; headers.len()]
-            };
+            if let Some(uncle_hashes) = uncle_hashes.as_ref() {
+                return_if_failed!(verify_extra_hash(&headers, uncle_hashes, &extensions));
+            }
 
             // Verify the proof
             return_if_failed!(verify_mmr_proof(

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -68,7 +68,7 @@ impl<'a> SendTransactionsProofProcess<'a> {
             if uncle_hashes_len != filtered_blocks_len || extensions_len != filtered_blocks_len {
                 let error_message = format!(
                     "SendTransactionsProof v1 field length mismatch: \
-                     headers={}, uncle_hashes={}, extensions={}",
+                     filtered_blocks={}, uncle_hashes={}, extensions={}",
                     filtered_blocks_len, uncle_hashes_len, extensions_len
                 );
                 return StatusCode::MalformedProtocolMessage.with_context(error_message);

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -138,6 +138,17 @@ impl<'a> SendTransactionsProofProcess<'a> {
                     .map(|extension| extension.to_entity().to_opt())
                     .collect();
 
+                if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+                    let errmsg = format!(
+                        "SendTransactionsProof v1 field length mismatch: \
+                         headers={}, uncle_hashes={}, extensions={}",
+                        headers.len(),
+                        uncle_hashes.len(),
+                        extensions.len()
+                    );
+                    return StatusCode::MalformedProtocolMessage.with_context(errmsg);
+                }
+
                 return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
                 extensions
             } else {

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -57,53 +57,28 @@ impl<'a> SendTransactionsProofProcess<'a> {
         };
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
-        let filtered_blocks: Vec<packed::FilteredBlock> = self
-            .message
-            .filtered_blocks()
-            .to_entity()
-            .into_iter()
-            .collect();
-        let headers: Vec<_> = filtered_blocks
-            .iter()
-            .map(|block| block.header().into_view())
-            .collect();
-
+        let filtered_blocks_len = self.message.filtered_blocks().len();
         let is_v1 = self.message.count_extra_fields() >= 2;
-        let (uncle_hashes, extensions) = if is_v1 {
+        if is_v1 {
             let message_v1 =
                 packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
-            let uncle_hashes: Vec<_> = message_v1
-                .blocks_uncles_hash()
-                .iter()
-                .map(|uncle_hashes| uncle_hashes.to_entity())
-                .collect();
+            let uncle_hashes_len = message_v1.blocks_uncles_hash().len();
+            let extensions_len = message_v1.blocks_extension().len();
 
-            let extensions: Vec<_> = message_v1
-                .blocks_extension()
-                .iter()
-                .map(|extension| extension.to_entity().to_opt())
-                .collect();
-
-            if uncle_hashes.len() != headers.len() || extensions.len() != headers.len() {
+            if uncle_hashes_len != filtered_blocks_len || extensions_len != filtered_blocks_len {
                 let error_message = format!(
                     "SendTransactionsProof v1 field length mismatch: \
                      headers={}, uncle_hashes={}, extensions={}",
-                    headers.len(),
-                    uncle_hashes.len(),
-                    extensions.len()
+                    filtered_blocks_len, uncle_hashes_len, extensions_len
                 );
                 return StatusCode::MalformedProtocolMessage.with_context(error_message);
             }
-
-            (Some(uncle_hashes), extensions)
-        } else {
-            (None, vec![None; headers.len()])
-        };
+        }
 
         // Update the last state if the response contains a new one.
         if original_request.last_hash() != last_header.header().hash() {
             if self.message.proof().is_empty()
-                && filtered_blocks.is_empty()
+                && self.message.filtered_blocks().is_empty()
                 && self.message.missing_tx_hashes().is_empty()
             {
                 return_if_failed!(self
@@ -122,6 +97,17 @@ impl<'a> SendTransactionsProofProcess<'a> {
                 return StatusCode::UnexpectedResponse.into();
             }
         }
+
+        let filtered_blocks: Vec<packed::FilteredBlock> = self
+            .message
+            .filtered_blocks()
+            .to_entity()
+            .into_iter()
+            .collect();
+        let headers: Vec<_> = filtered_blocks
+            .iter()
+            .map(|block| block.header().into_view())
+            .collect();
 
         // Check if the response is match the request.
         let received_tx_hashes = filtered_blocks
@@ -153,9 +139,25 @@ impl<'a> SendTransactionsProofProcess<'a> {
             return_if_failed!(self.protocol.check_pow_for_headers(headers.iter()));
 
             // Check extra hash for blocks
-            if let Some(uncle_hashes) = uncle_hashes.as_ref() {
-                return_if_failed!(verify_extra_hash(&headers, uncle_hashes, &extensions));
-            }
+            let extensions = if is_v1 {
+                let message_v1 =
+                    packed::SendTransactionsProofV1Reader::new_unchecked(self.message.as_slice());
+                let uncle_hashes: Vec<_> = message_v1
+                    .blocks_uncles_hash()
+                    .iter()
+                    .map(|uncle_hashes| uncle_hashes.to_entity())
+                    .collect();
+                let extensions: Vec<_> = message_v1
+                    .blocks_extension()
+                    .iter()
+                    .map(|extension| extension.to_entity().to_opt())
+                    .collect();
+
+                return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
+                extensions
+            } else {
+                vec![None; headers.len()]
+            };
 
             // Verify the proof
             return_if_failed!(verify_mmr_proof(

--- a/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
@@ -451,7 +451,7 @@ async fn rejects_v1_fields_when_all_blocks_are_missing() {
         last_block_number: 20,
         missing_block_hashes: missing_block_hashes.clone(),
         returned_missing_block_hashes: missing_block_hashes,
-        returned_uncles_hash: Some(vec![packed::Byte32::default()]),
+        returned_uncles_hashes: Some(vec![packed::Byte32::default()]),
         expected_status: Some(StatusCode::MalformedProtocolMessage),
         ..Default::default()
     };
@@ -630,7 +630,7 @@ struct TestParameter {
     returned_headers: Vec<BlockNumber>,
     missing_block_hashes: Vec<packed::Byte32>,
     returned_missing_block_hashes: Vec<packed::Byte32>,
-    returned_uncles_hash: Option<Vec<packed::Byte32>>,
+    returned_uncles_hashes: Option<Vec<packed::Byte32>>,
     expected_status: Option<StatusCode>,
 }
 
@@ -723,13 +723,13 @@ async fn test_send_blocks_proof(param: TestParameter) {
             if param.proved_block_numbers == all_block_numbers {
                 assert!(proof.is_empty());
             }
-            if let Some(uncles_hash) = &param.returned_uncles_hash {
+            if let Some(uncles_hashes) = &param.returned_uncles_hashes {
                 let content = packed::SendBlocksProofV1::new_builder()
                     .last_header(last_header)
                     .proof(proof)
                     .headers(headers.pack())
                     .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
-                    .blocks_uncles_hash(uncles_hash.to_owned().pack())
+                    .blocks_uncles_hash(uncles_hashes.to_owned().pack())
                     .build();
                 packed::LightClientMessage::new_builder()
                     .set(content)

--- a/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
@@ -439,6 +439,21 @@ async fn empty_proof_since_all_blocks_are_missing() {
         returned_headers: block_numbers,
         missing_block_hashes: missing_block_hashes.clone(),
         returned_missing_block_hashes: missing_block_hashes,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_v1_fields_when_all_blocks_are_missing() {
+    let missing_block_hashes = vec![h256!("0x1").pack(), h256!("0x2").pack()];
+    let param = TestParameter {
+        last_block_number: 20,
+        missing_block_hashes: missing_block_hashes.clone(),
+        returned_missing_block_hashes: missing_block_hashes,
+        returned_uncles_hash: Some(vec![packed::Byte32::default()]),
+        expected_status: Some(StatusCode::MalformedProtocolMessage),
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -456,6 +471,7 @@ async fn nonempty_proof_since_all_blocks_are_missing() {
         returned_headers,
         missing_block_hashes: missing_block_hashes.clone(),
         returned_missing_block_hashes: missing_block_hashes,
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -472,6 +488,7 @@ async fn valid_proof_with_missing_block_hashes() {
         returned_headers: block_numbers,
         missing_block_hashes: missing_block_hashes.clone(),
         returned_missing_block_hashes: missing_block_hashes,
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -489,6 +506,7 @@ async fn invalid_proof_with_insufficient_missing_block_hashes() {
         returned_headers: block_numbers,
         missing_block_hashes,
         returned_missing_block_hashes,
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -506,6 +524,7 @@ async fn invalid_proof_with_redundant_missing_block_hashes() {
         returned_headers: block_numbers,
         missing_block_hashes,
         returned_missing_block_hashes,
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -523,6 +542,7 @@ async fn invalid_proof_with_duplicate_missing_block_hashes() {
         returned_headers: block_numbers,
         missing_block_hashes,
         returned_missing_block_hashes,
+        ..Default::default()
     };
     test_send_blocks_proof(param).await;
 }
@@ -610,6 +630,8 @@ struct TestParameter {
     returned_headers: Vec<BlockNumber>,
     missing_block_hashes: Vec<packed::Byte32>,
     returned_missing_block_hashes: Vec<packed::Byte32>,
+    returned_uncles_hash: Option<Vec<packed::Byte32>>,
+    expected_status: Option<StatusCode>,
 }
 
 async fn test_send_blocks_proof(param: TestParameter) {
@@ -701,15 +723,28 @@ async fn test_send_blocks_proof(param: TestParameter) {
             if param.proved_block_numbers == all_block_numbers {
                 assert!(proof.is_empty());
             }
-            let content = packed::SendBlocksProof::new_builder()
-                .last_header(last_header)
-                .proof(proof)
-                .headers(headers.pack())
-                .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
-                .build();
-            packed::LightClientMessage::new_builder()
-                .set(content)
-                .build()
+            if let Some(uncles_hash) = &param.returned_uncles_hash {
+                let content = packed::SendBlocksProofV1::new_builder()
+                    .last_header(last_header)
+                    .proof(proof)
+                    .headers(headers.pack())
+                    .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
+                    .blocks_uncles_hash(uncles_hash.to_owned().pack())
+                    .build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            } else {
+                let content = packed::SendBlocksProof::new_builder()
+                    .last_header(last_header)
+                    .proof(proof)
+                    .headers(headers.pack())
+                    .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
+                    .build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            }
         }
         .as_bytes();
 
@@ -717,7 +752,10 @@ async fn test_send_blocks_proof(param: TestParameter) {
 
         protocol.received(nc.context(), peer_index, data).await;
 
-        if param.block_numbers == param.proved_block_numbers
+        if let Some(expected_status) = param.expected_status {
+            assert!(nc.banned_since(peer_index, expected_status));
+            assert!(nc.sent_messages().borrow().is_empty());
+        } else if param.block_numbers == param.proved_block_numbers
             && param.block_numbers == param.returned_headers
             && param.missing_block_hashes == param.returned_missing_block_hashes
         {

--- a/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -485,6 +485,78 @@ async fn test_empty_txs_proof(with_unexpected_extension: bool, last_state_change
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rejects_malformed_v1_extra_fields() {
+    // A V1 proof whose trailing `blocks_extension` field is too short to hold a
+    // Molecule Vec header (total_size + item_count). The base message still
+    // parses, so the response reaches the handler, but the V1 extra field is
+    // structurally invalid. Under the previous `new_unchecked` + `.len()` path
+    // this panicked inside `unpack_number`; with the validating reader it must
+    // be rejected as a malformed protocol message instead.
+    let chain = MockChain::new_with_dummy_pow("test-send-txs").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+    let peer_index = PeerIndex::new(3);
+
+    chain.mine_to(20);
+    let last_header = chain
+        .shared()
+        .snapshot()
+        .get_verifiable_header_by_number(20)
+        .unwrap();
+
+    // Build a structurally valid V1 message, then truncate its trailing field.
+    let extension = packed::BytesOpt::new_builder()
+        .set(Some(packed::Bytes::default()))
+        .build();
+    let content = packed::SendTransactionsProofV1::new_builder()
+        .last_header(last_header.clone())
+        .blocks_extension(vec![extension])
+        .build();
+
+    let mut bytes = content.as_slice().to_vec();
+    {
+        // `blocks_extension` is the last field, so it occupies the tail
+        // `[extension_offset, total_size)` of the table.
+        let reader = packed::SendTransactionsProofV1Reader::new_unchecked(&bytes);
+        let extension_len = reader.blocks_extension().as_slice().len();
+        let mut header = [0u8; 4];
+        header.copy_from_slice(&bytes[0..4]);
+        let total_size = u32::from_le_bytes(header) as usize;
+        let extension_offset = total_size - extension_len;
+        // Keep only 2 bytes of the trailing field: too short for a Vec header,
+        // so `from_compatible_slice` rejects it while the base message still
+        // parses.
+        bytes.truncate(extension_offset + 2);
+        let new_total = bytes.len() as u32;
+        bytes[0..4].copy_from_slice(&new_total.to_le_bytes());
+    }
+    let malformed = packed::SendTransactionsProofV1::new_unchecked(bytes.into());
+    let message = packed::LightClientMessage::new_builder()
+        .set(malformed)
+        .build();
+
+    let peers = {
+        let peers = chain.create_peers();
+        let txs_proof_request = packed::GetTransactionsProof::new_builder()
+            .last_hash(last_header.header().calc_header_hash())
+            .build();
+        peers.add_peer(peer_index);
+        peers
+            .mock_prove_state(peer_index, last_header.into())
+            .unwrap();
+        peers.update_txs_proof_request(peer_index, Some(txs_proof_request));
+        peers
+    };
+
+    let mut protocol = chain.create_light_client_protocol(Arc::clone(&peers));
+    protocol
+        .received(nc.context(), peer_index, message.as_bytes())
+        .await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::MalformedProtocolMessage));
+    assert!(nc.sent_messages().borrow().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_send_headers_txs_request() {
     let chain = MockChain::new_with_dummy_pow("test-send-headers-txs").start();
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);

--- a/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -414,6 +414,15 @@ async fn test_send_txs_proof_invalid_merkle_proof() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_send_txs_proof_is_empty() {
+    test_empty_txs_proof(false, false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_v1_fields_before_processing_changed_last_state() {
+    test_empty_txs_proof(true, true).await;
+}
+
+async fn test_empty_txs_proof(with_unexpected_extension: bool, last_state_changed: bool) {
     let chain = MockChain::new_with_dummy_pow("test-send-txs").start();
     let nc = MockNetworkContext::new(SupportProtocols::LightClient);
     let peer_index = PeerIndex::new(3);
@@ -425,7 +434,18 @@ async fn test_send_txs_proof_is_empty() {
         .snapshot()
         .get_verifiable_header_by_number(20)
         .unwrap();
-    let message = {
+    let message = if with_unexpected_extension {
+        let unexpected_extension = packed::BytesOpt::new_builder()
+            .set(Some(packed::Bytes::default()))
+            .build();
+        let content = packed::SendTransactionsProofV1::new_builder()
+            .last_header(last_header.clone())
+            .blocks_extension(vec![unexpected_extension])
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    } else {
         let content = packed::SendTransactionsProof::new_builder()
             .last_header(last_header.clone())
             .build();
@@ -437,7 +457,11 @@ async fn test_send_txs_proof_is_empty() {
     let peers = {
         let peers = chain.create_peers();
         let txs_proof_request = packed::GetTransactionsProof::new_builder()
-            .last_hash(last_header.header().calc_header_hash())
+            .last_hash(if last_state_changed {
+                packed::Byte32::default()
+            } else {
+                last_header.header().calc_header_hash()
+            })
             .build();
         peers.add_peer(peer_index);
         peers
@@ -452,7 +476,11 @@ async fn test_send_txs_proof_is_empty() {
         .received(nc.context(), peer_index, message.as_bytes())
         .await;
 
-    assert!(nc.not_banned(peer_index));
+    if with_unexpected_extension {
+        assert!(nc.banned_since(peer_index, StatusCode::MalformedProtocolMessage));
+    } else {
+        assert!(nc.not_banned(peer_index));
+    }
     assert!(nc.sent_messages().borrow().is_empty());
 }
 


### PR DESCRIPTION
  This PR strengthens validation for V1 proof responses and avoids treating a local checkpoint-storage inconsistency as a peer error.

  - Validate that `blocks_uncles_hash` and `blocks_extension` contain exactly one entry for each returned header in:
    - `SendBlocksProofV1`
    - `SendTransactionsProofV1`
  - Perform this structural validation before empty-response and changed-last-state early returns.
  - Return `MalformedProtocolMessage` for mismatched V1 field lengths.
  - Replace the panic when an expected local checkpoint is missing with `InternalError`.