### PR TITLE
Require proof before advancing subscribed tips

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state.rs
@@ -36,7 +36,7 @@ impl<'a> SendLastStateProcess<'a> {
 
         let last_state = LastState::new(last_header);
 
-        if let Some(prev_last_state) = peer_state.get_last_state() {
+        let is_updated = if let Some(prev_last_state) = peer_state.get_last_state() {
             if last_state.is_same_as(prev_last_state) {
                 trace!(
                     "peer {}: receive the same last state as previous {}",
@@ -45,6 +45,7 @@ impl<'a> SendLastStateProcess<'a> {
                 );
                 // Do NOT update the timestamp for same last state,
                 // so it could be banned after timeout check.
+                false
             } else {
                 trace!(
                     "peer {}: update last state from {} to {}",
@@ -56,23 +57,8 @@ impl<'a> SendLastStateProcess<'a> {
                 return_if_failed!(self
                     .protocol
                     .peers()
-                    .update_last_state(self.peer_index, last_state.clone()));
-
-                if prev_last_state.total_difficulty() < last_state.total_difficulty() {
-                    if let Some(prove_state) = peer_state.get_prove_state() {
-                        if prove_state.is_parent_of(&last_state) {
-                            trace!("peer {}: new last state could be trusted", self.peer_index);
-                            let last_n_blocks = self.protocol.last_n_blocks() as usize;
-                            let child_prove_state =
-                                prove_state.new_child(last_state, last_n_blocks);
-                            return_if_failed!(
-                                self.protocol
-                                    .update_prove_state_to_child(self.peer_index, child_prove_state)
-                                    .await
-                            );
-                        }
-                    }
-                }
+                    .update_last_state(self.peer_index, last_state));
+                true
             }
         } else {
             trace!(
@@ -85,7 +71,10 @@ impl<'a> SendLastStateProcess<'a> {
                 .protocol
                 .peers()
                 .update_last_state(self.peer_index, last_state));
+            true
+        };
 
+        if is_updated {
             let is_sent = return_if_failed!(
                 self.protocol
                     .get_last_state_proof(self.nc, self.peer_index)

--- a/light-client-lib/src/protocols/light_client/mod.rs
+++ b/light-client-lib/src/protocols/light_client/mod.rs
@@ -314,26 +314,6 @@ impl LightClientProtocol {
         Ok(())
     }
 
-    /// Update the prove state to the child block.
-    /// - Update the peer's cache.
-    /// - Try to update the storage without caring about fork.
-    async fn update_prove_state_to_child(
-        &self,
-        peer_index: PeerIndex,
-        new_prove_state: ProveState,
-    ) -> Result<(), Status> {
-        let (old_total_difficulty, _) = self.storage.get_last_state();
-        let new_total_difficulty = new_prove_state.get_last_header().total_difficulty();
-        if new_total_difficulty > old_total_difficulty {
-            self.storage.update_last_state(
-                &new_total_difficulty,
-                &new_prove_state.get_last_header().header().data(),
-                new_prove_state.get_last_headers(),
-            );
-        }
-        self.peers().update_prove_state(peer_index, new_prove_state)
-    }
-
     /// Update the prove state base on the previous request.
     /// - Update the peer's cache.
     /// - Try to update the storage and handle potential fork.

--- a/light-client-lib/src/protocols/light_client/peers.rs
+++ b/light-client-lib/src/protocols/light_client/peers.rs
@@ -12,12 +12,11 @@ use ckb_types::{
     packed::Byte32,
     prelude::*,
     utilities::merkle_mountain_range::VerifiableHeader,
-    H256, U256,
+    H256,
 };
 use dashmap::DashMap;
 use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
 
-use super::prelude::*;
 use crate::{
     mutex_lock,
     protocols::{Status, StatusCode, BAD_MESSAGE_ALLOWED_EACH_HOUR, MESSAGE_TIMEOUT},
@@ -256,14 +255,6 @@ impl LastState {
         }
     }
 
-    pub(crate) fn total_difficulty(&self) -> U256 {
-        self.as_ref().total_difficulty()
-    }
-
-    pub(crate) fn header(&self) -> &HeaderView {
-        self.as_ref().header()
-    }
-
     pub(crate) fn update_ts(&self) -> u64 {
         self.update_ts
     }
@@ -380,28 +371,6 @@ impl ProveState {
             reorg_last_headers,
             last_headers,
         }
-    }
-
-    pub(crate) fn new_child(&self, child_last_state: LastState, last_n_blocks: usize) -> Self {
-        let parent_header = self.get_last_header().header();
-        let mut last_headers = self.last_headers.clone();
-        let reorg_last_headers = self.reorg_last_headers.clone();
-        // To avoid unlimited memory growth.
-        if last_headers.len() >= last_n_blocks {
-            last_headers.remove(0);
-        }
-        last_headers.push(parent_header.clone());
-        Self {
-            last_state: child_last_state,
-            reorg_last_headers,
-            last_headers,
-        }
-    }
-
-    pub(crate) fn is_parent_of(&self, child_last_state: &LastState) -> bool {
-        self.get_last_header()
-            .header()
-            .is_parent_of(child_last_state.header())
     }
 
     pub fn get_last_header(&self) -> &VerifiableHeader {

--- a/light-client-lib/src/tests/protocols/light_client/send_last_state.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_last_state.rs
@@ -7,12 +7,48 @@ use ckb_types::{
 };
 
 use crate::{
-    protocols::{LastState, ProveRequest, ProveState, StatusCode},
+    protocols::{
+        light_client::prelude::HeaderUtils, LastState, LightClientProtocol, ProveRequest,
+        ProveState, StatusCode,
+    },
+    storage::LightClientStorage,
     tests::{
         prelude::*,
         utils::{MockChain, MockNetworkContext},
     },
 };
+
+fn assert_last_state_proof_requested(
+    network_context: &MockNetworkContext,
+    expected_last_hash: &packed::Byte32,
+) {
+    let sent_messages = network_context.sent_messages().borrow();
+    assert_eq!(sent_messages.len(), 1);
+    let sent_message_bytes = &sent_messages[0].2;
+    let message = packed::LightClientMessageReader::new_unchecked(sent_message_bytes);
+    let content = if let packed::LightClientMessageUnionReader::GetLastStateProof(content) =
+        message.to_enum()
+    {
+        content
+    } else {
+        panic!("unexpected message");
+    };
+    assert_eq!(
+        content.last_hash().as_slice(),
+        expected_last_hash.as_slice()
+    );
+}
+
+fn prove_state_is_parent_of(prove_state: &ProveState, last_state: &LastState) -> bool {
+    prove_state
+        .get_last_header()
+        .header()
+        .is_parent_of(last_state.as_ref().header())
+}
+
+fn stored_last_header(protocol: &LightClientProtocol) -> packed::Header {
+    protocol.storage().get_last_state().1
+}
 
 #[tokio::test]
 async fn peer_state_is_not_found() {
@@ -153,18 +189,7 @@ async fn initialize_last_state() {
         .get_peer_state(&peer_index)
         .expect("has peer state");
     assert!(peer_state.get_last_state().is_some());
-    assert_eq!(nc.sent_messages().borrow().len(), 1);
-
-    let data = &nc.sent_messages().borrow()[0].2;
-    let message = packed::LightClientMessageReader::new_unchecked(data);
-    let content = if let packed::LightClientMessageUnionReader::GetLastStateProof(content) =
-        message.to_enum()
-    {
-        content
-    } else {
-        panic!("unexpected message");
-    };
-    assert_eq!(content.last_hash().as_slice(), last_hash.as_slice());
+    assert_last_state_proof_requested(&nc, &last_hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -304,25 +329,30 @@ async fn update_to_continuous_last_state() {
         let last_header: VerifiableHeader = last_header.into();
         let last_state = LastState::new(last_header.clone());
 
-        let prove_state = protocol
+        let prove_state_before = protocol
             .get_peer_state(&peer_index)
             .expect("has peer state")
             .get_prove_state()
             .expect("has prove state")
             .to_owned();
-        assert!(prove_state.is_parent_of(&last_state));
+        assert!(prove_state_is_parent_of(&prove_state_before, &last_state));
+        let stored_last_header_before = stored_last_header(&protocol);
 
         protocol.received(nc.context(), peer_index, data).await;
 
-        assert!(nc.sent_messages().borrow().is_empty());
+        assert_last_state_proof_requested(&nc, &last_header.header().hash());
 
-        let prove_state = protocol
+        let prove_state_after = protocol
             .get_peer_state(&peer_index)
             .expect("has peer state")
             .get_prove_state()
             .expect("has prove state")
             .to_owned();
-        assert!(prove_state.is_same_as(&last_header));
+        assert!(prove_state_after.is_same_as(prove_state_before.get_last_header()));
+        assert_eq!(
+            stored_last_header(&protocol).as_slice(),
+            stored_last_header_before.as_slice()
+        );
     }
 }
 
@@ -410,11 +440,11 @@ async fn update_to_noncontinuous_last_state() {
             .get_prove_state()
             .expect("has prove state")
             .to_owned();
-        assert!(!prove_state.is_parent_of(&last_state));
+        assert!(!prove_state_is_parent_of(&prove_state, &last_state));
 
         protocol.received(nc.context(), peer_index, data).await;
 
-        assert!(nc.sent_messages().borrow().is_empty());
+        assert_last_state_proof_requested(&nc, &last_header.header().hash());
 
         let prove_state = protocol
             .get_peer_state(&peer_index)
@@ -534,7 +564,7 @@ async fn update_to_continuous_but_forked_last_state() {
             .get_prove_state()
             .expect("has prove state")
             .to_owned();
-        assert!(!prove_state.is_parent_of(&last_state));
+        assert!(!prove_state_is_parent_of(&prove_state, &last_state));
 
         protocol.received(nc.context(), peer_index, data).await;
 


### PR DESCRIPTION
## Summary

- Route changed subscribed tip announcements through the existing last-state proof flow.
- Keep the trusted prove state and persisted tip unchanged until proof validation completes.
- Remove the direct child-promotion helpers.
- Add regression coverage for continuous and non-contiguous tip updates.

## Why

A subscribed peer's child announcement was previously promoted using its parent relationship and header-local checks. Those checks do not establish that the child consistently extends the previously proved chain state.

Treating the message as an advertisement and using the existing proof flow preserves the distinction between peer-reported state and trusted state.

## Impact

Changed tip announcements may produce an additional proof request. Unchanged announcements remain no-ops, and a tip already proved through another peer can still reuse that verified state.

## Validation

- `cargo fmt --all --check`
- `cargo check -p ckb-light-client-lib --locked`
- `cargo clippy -p ckb-light-client-lib --locked -- --deny warnings`
- Wasm Clippy with warnings denied
- Native CLI Clippy with warnings denied
- `cargo nextest run -p ckb-light-client-lib -p ckb-light-client` — 116 tests passed
