### PR TITLE
Validate downloaded block data before indexing

### DIFF
--- a/light-client-lib/src/protocols/synchronizer.rs
+++ b/light-client-lib/src/protocols/synchronizer.rs
@@ -71,28 +71,47 @@ impl CKBProtocolHandler for SyncProtocol {
         match message {
             packed::SyncMessageUnionReader::SendBlock(reader) => {
                 let new_block = reader.to_entity().block();
-                let mut matched_blocks = self.peers.matched_blocks().write().await;
                 let block_hash = new_block.header().calc_header_hash();
-                let should_validate = matched_blocks
-                    .get(&block_hash.unpack())
-                    .map(|(proved, _)| *proved)
-                    .unwrap_or(false);
-                if should_validate {
-                    let block = new_block.clone().into_view_without_reset_header();
-                    if !block_body_matches_header(&block) {
-                        warn!(
-                            "SyncProtocol received a block whose body does not match \
-                             the proved header from peer={}",
-                            peer
-                        );
-                        nc.ban_peer(
-                            peer,
-                            BAD_MESSAGE_BAN_TIME,
-                            String::from("block body does not match header"),
-                        );
-                        return;
+                let block_hash_key = block_hash.unpack();
+                let mut body_validated = false;
+                // The proof state can change after releasing the read lock. Recheck it
+                // under the write lock and validate before caching if it became proved.
+                let mut matched_blocks = loop {
+                    let should_validate = self
+                        .peers
+                        .matched_blocks()
+                        .read()
+                        .await
+                        .get(&block_hash_key)
+                        .is_some_and(|(proved, _)| *proved);
+                    if should_validate && !body_validated {
+                        let block = new_block.clone().into_view_without_reset_header();
+                        if !block_body_matches_header(&block) {
+                            warn!(
+                                "SyncProtocol received a block whose body does not match \
+                                 the proved header from peer={}",
+                                peer
+                            );
+                            nc.ban_peer(
+                                peer,
+                                BAD_MESSAGE_BAN_TIME,
+                                String::from("block body does not match header"),
+                            );
+                            return;
+                        }
+                        body_validated = true;
                     }
-                }
+
+                    let matched_blocks = self.peers.matched_blocks().write().await;
+                    let is_proved = matched_blocks
+                        .get(&block_hash_key)
+                        .is_some_and(|(proved, _)| *proved);
+                    if is_proved && !body_validated {
+                        drop(matched_blocks);
+                        continue;
+                    }
+                    break matched_blocks;
+                };
                 self.peers.add_block(&mut matched_blocks, new_block);
                 if !matched_blocks.is_empty()
                     && self.peers.all_matched_blocks_downloaded(&matched_blocks)

--- a/light-client-lib/src/protocols/synchronizer.rs
+++ b/light-client-lib/src/protocols/synchronizer.rs
@@ -1,11 +1,12 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use ckb_constant::sync::INIT_BLOCKS_IN_TRANSIT_PER_PEER;
 use ckb_network::{
     async_trait, bytes::Bytes, BoxedCKBProtocolContext, CKBProtocolHandler, PeerIndex,
 };
-use ckb_types::{packed, prelude::*};
+use ckb_types::{core::BlockView, packed, prelude::*};
 use log::{info, trace, warn};
-use std::collections::HashSet;
-use std::sync::Arc;
 
 use super::BAD_MESSAGE_BAN_TIME;
 use crate::protocols::Peers;
@@ -15,6 +16,16 @@ use crate::utils::network::prove_or_download_matched_blocks;
 pub struct SyncProtocol {
     storage: Storage,
     peers: Arc<Peers>,
+}
+
+fn block_body_matches_header(block: &BlockView) -> bool {
+    block.transactions_root() == block.calc_transactions_root()
+        && block.proposals_hash() == block.calc_proposals_hash()
+        && block.extra_hash() == block.calc_extra_hash().extra_hash()
+        && block
+            .uncles()
+            .into_iter()
+            .all(|uncle| uncle.proposals_hash() == uncle.calc_proposals_hash())
 }
 
 impl SyncProtocol {
@@ -61,6 +72,27 @@ impl CKBProtocolHandler for SyncProtocol {
             packed::SyncMessageUnionReader::SendBlock(reader) => {
                 let new_block = reader.to_entity().block();
                 let mut matched_blocks = self.peers.matched_blocks().write().await;
+                let block_hash = new_block.header().calc_header_hash();
+                let should_validate = matched_blocks
+                    .get(&block_hash.unpack())
+                    .map(|(proved, _)| *proved)
+                    .unwrap_or(false);
+                if should_validate {
+                    let block = new_block.clone().into_view_without_reset_header();
+                    if !block_body_matches_header(&block) {
+                        warn!(
+                            "SyncProtocol received a block whose body does not match \
+                             the proved header from peer={}",
+                            peer
+                        );
+                        nc.ban_peer(
+                            peer,
+                            BAD_MESSAGE_BAN_TIME,
+                            String::from("block body does not match header"),
+                        );
+                        return;
+                    }
+                }
                 self.peers.add_block(&mut matched_blocks, new_block);
                 if !matched_blocks.is_empty()
                     && self.peers.all_matched_blocks_downloaded(&matched_blocks)

--- a/light-client-lib/src/tests/protocols/synchronizer.rs
+++ b/light-client-lib/src/tests/protocols/synchronizer.rs
@@ -181,6 +181,19 @@ async fn rejects_block_with_extension_not_committed_by_header() {
 }
 
 #[tokio::test]
+async fn rejects_block_with_uncles_not_committed_by_header() {
+    let block_view = BlockBuilder::default().build();
+    let received_uncle = packed::UncleBlock::new_builder().build();
+    let received_block = block_view
+        .data()
+        .as_builder()
+        .uncles(vec![received_uncle].pack())
+        .build();
+
+    assert_rejects_block_body(block_view, received_block).await;
+}
+
+#[tokio::test]
 async fn rejects_block_with_uncle_proposals_not_committed_by_uncle_header() {
     let uncle = packed::UncleBlock::new_builder().build().into_view();
     let block_view = BlockBuilder::default().uncle(uncle.clone()).build();

--- a/light-client-lib/src/tests/protocols/synchronizer.rs
+++ b/light-client-lib/src/tests/protocols/synchronizer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ckb_network::{CKBProtocolHandler, PeerIndex, SupportProtocols};
 use ckb_types::{
-    core::BlockBuilder,
+    core::{BlockBuilder, BlockView},
     packed::{self, Script},
     prelude::*,
 };
@@ -85,4 +85,115 @@ async fn test_sync_add_block() {
     let filtered_block_number = start_number - 1 + blocks_count;
     assert_eq!(storage_filtered_block_number, filtered_block_number);
     assert!(nc.sent_messages().borrow().is_empty());
+}
+
+async fn assert_rejects_block_body(block_view: BlockView, received_block: packed::Block) {
+    let chain = MockChain::new_with_dummy_pow("test-sync");
+    let network_context = MockNetworkContext::new(SupportProtocols::Sync);
+
+    let scripts = vec![ScriptStatus {
+        script: Script::default(),
+        script_type: ScriptType::Lock,
+        block_number: 1,
+    }];
+    chain
+        .client_storage()
+        .update_filter_scripts(scripts, Default::default());
+
+    let proved_block_hash = block_view.hash();
+    chain
+        .client_storage()
+        .add_matched_blocks(2, 1, vec![(proved_block_hash.clone(), true)]);
+
+    let peer_index = PeerIndex::new(3);
+    let peers = {
+        let peers = chain.create_peers();
+        peers.add_peer(peer_index);
+        {
+            let mut matched_blocks = peers.matched_blocks().write().await;
+            peers.add_matched_blocks(&mut matched_blocks, vec![(proved_block_hash.clone(), true)]);
+        }
+        peers
+    };
+
+    let message = packed::SyncMessage::new_builder()
+        .set(
+            packed::SendBlock::new_builder()
+                .block(received_block)
+                .build(),
+        )
+        .build()
+        .as_bytes();
+
+    let mut protocol = chain.create_sync_protocol(Arc::clone(&peers));
+    protocol
+        .received(network_context.context(), peer_index, message)
+        .await;
+
+    assert!(network_context.has_banned(peer_index).is_some());
+    assert!(peers
+        .matched_blocks()
+        .read()
+        .await
+        .get(&proved_block_hash.unpack())
+        .is_some_and(|(_, block)| block.is_none()));
+    assert!(chain
+        .client_storage()
+        .get_earliest_matched_blocks()
+        .is_some());
+}
+
+#[tokio::test]
+async fn rejects_block_with_transactions_not_committed_by_header() {
+    let block_view = BlockBuilder::default().build();
+    let received_block = block_view
+        .data()
+        .as_builder()
+        .transactions(vec![packed::Transaction::default()].pack())
+        .build();
+
+    assert_rejects_block_body(block_view, received_block).await;
+}
+
+#[tokio::test]
+async fn rejects_block_with_proposals_not_committed_by_header() {
+    let block_view = BlockBuilder::default().build();
+    let received_block = block_view
+        .data()
+        .as_builder()
+        .proposals(vec![packed::ProposalShortId::default()].pack())
+        .build();
+
+    assert_rejects_block_body(block_view, received_block).await;
+}
+
+#[tokio::test]
+async fn rejects_block_with_extension_not_committed_by_header() {
+    let extension = packed::Bytes::new_builder().push(1u8).build();
+    let block_view = BlockBuilder::default().build();
+    let received_block = block_view
+        .as_advanced_builder()
+        .extension(Some(extension))
+        .build_unchecked()
+        .data();
+
+    assert_rejects_block_body(block_view, received_block).await;
+}
+
+#[tokio::test]
+async fn rejects_block_with_uncle_proposals_not_committed_by_uncle_header() {
+    let uncle = packed::UncleBlock::new_builder().build().into_view();
+    let block_view = BlockBuilder::default().uncle(uncle.clone()).build();
+    let received_uncle = uncle
+        .data()
+        .as_builder()
+        .proposals(vec![packed::ProposalShortId::default()].pack())
+        .build();
+    let received_block = block_view
+        .data()
+        .as_builder()
+        .uncles(vec![received_uncle].pack())
+        .build();
+
+    assert_rejects_block_body(block_view, received_block).await;
 }


### PR DESCRIPTION
## Summary

- verify downloaded block data against commitments in its proved header
- reject inconsistent responses while keeping the matched block pending for another peer
- avoid holding the matched-block write lock while recalculating body commitments
- cover transactions and witnesses, proposals, uncles, extensions, and uncle proposals with synchronizer tests

## Why

A header proof authenticates the header. The downloaded full block must also match the commitments in that header before its transactions are indexed.

## Behavior

Valid proved blocks continue through the existing indexing path. Validation runs only for matched blocks already marked as proved. Inconsistent responses are rejected before the block is cached or the pending queue is cleared.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ckb-light-client-lib --locked -- --deny warnings`
- `cargo clippy --target wasm32-unknown-unknown -p light-client-wasm -p ckb-light-client-lib -p light-client-db-common -p light-client-db-worker --locked -- --deny warnings`
- `cargo nextest run -p ckb-light-client-lib synchronizer` (6 passed)
- `cargo nextest run --hide-progress-bar --success-output immediate --failure-output immediate -p ckb-light-client-lib` (112 passed)

The combined library and CLI test command could not start in this environment because `tikv-jemalloc-sys` failed to build against the local Nix/glibc toolchain.