### PR TITLE
Validate verifiable headers before processing last state proof

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_last_state_proof.rs
@@ -53,6 +53,8 @@ impl<'a> SendLastStateProofProcess<'a> {
 
         let last_header: VerifiableHeader = self.message.last_header().to_entity().into();
 
+        return_if_failed!(self.protocol.check_verifiable_header(&last_header));
+
         // Update the last state if the response contains a new one.
         if !original_request.is_same_as(&last_header) {
             if self.message.proof().is_empty() {

--- a/light-client-lib/src/protocols/light_client/mod.rs
+++ b/light-client-lib/src/protocols/light_client/mod.rs
@@ -18,7 +18,7 @@ use ckb_types::{
     core::{BlockNumber, EpochNumber, HeaderView},
     packed,
     prelude::*,
-    utilities::merkle_mountain_range::VerifiableHeader,
+    utilities::{compact_to_difficulty, merkle_mountain_range::VerifiableHeader},
     U256,
 };
 
@@ -297,6 +297,26 @@ impl LightClientProtocol {
                 header.hash()
             );
             return Err(StatusCode::InvalidChainRoot.with_context(errmsg));
+        }
+        // Check Total Difficulty
+        let parent_total_difficulty: U256 = verifiable_header
+            .parent_chain_root()
+            .total_difficulty()
+            .into();
+        let block_difficulty = compact_to_difficulty(header.compact_target());
+        if parent_total_difficulty
+            .checked_add(&block_difficulty)
+            .is_none()
+        {
+            let errmsg = format!(
+                "failed to verify total difficulty for block#{}, hash: {:#x}, \
+                 parent total difficulty: {:#x}, block difficulty: {:#x}",
+                header.number(),
+                header.hash(),
+                parent_total_difficulty,
+                block_difficulty,
+            );
+            return Err(StatusCode::InvalidTotalDifficulty.with_context(errmsg));
         }
         Ok(())
     }

--- a/light-client-lib/src/tests/protocols/light_client/send_last_state_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_last_state_proof.rs
@@ -169,6 +169,125 @@ async fn update_last_state() {
     }
 }
 
+fn header_with_overflowing_total_difficulty(
+    base: packed::VerifiableHeader,
+) -> packed::VerifiableHeader {
+    base.as_builder()
+        .parent_chain_root(
+            packed::HeaderDigest::new_builder()
+                .total_difficulty(U256::max_value().pack())
+                .build(),
+        )
+        .build()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reject_last_header_with_overflowing_total_difficulty() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = {
+        let peers = chain.create_peers();
+        peers.add_peer(peer_index);
+        peers.request_last_state(peer_index).unwrap();
+        peers
+    };
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    let num = 12;
+    chain.mine_to(num + 2);
+    let snapshot = chain.shared().snapshot();
+
+    // Set up an outstanding GetLastStateProof request for a real header.
+    {
+        let peer_state = protocol
+            .get_peer_state(&peer_index)
+            .expect("has peer state");
+        let prove_request = {
+            let last_header: VerifiableHeader = snapshot
+                .get_verifiable_header_by_number(num)
+                .expect("block stored")
+                .into();
+            let content = protocol
+                .build_prove_request_content(&peer_state, &last_header)
+                .await
+                .expect("build prove request content");
+            let last_state = LastState::new(last_header);
+            protocol
+                .peers()
+                .update_last_state(peer_index, last_state.clone())
+                .unwrap();
+            ProveRequest::new(last_state, content)
+        };
+        protocol
+            .peers()
+            .update_prove_request(peer_index, prove_request)
+            .unwrap();
+    }
+
+    let last_header = header_with_overflowing_total_difficulty(
+        snapshot
+            .get_verifiable_header_by_number(1)
+            .expect("block stored"),
+    );
+    let data = {
+        let content = packed::SendLastStateProof::new_builder()
+            .last_header(last_header)
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidTotalDifficulty));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reject_same_last_header_with_overwritten_total_difficulty() {
+    let chain = MockChain::new_with_dummy_pow("test-light-client").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+
+    let peer_index = PeerIndex::new(1);
+    let peers = chain.create_peers();
+    peers.add_peer(peer_index);
+    let mut protocol = chain.create_light_client_protocol(peers);
+
+    chain.mine_to(3);
+    let snapshot = chain.shared().snapshot();
+
+    let outstanding_header = snapshot
+        .get_verifiable_header_by_number(1)
+        .expect("block stored");
+    {
+        let last_header: VerifiableHeader = outstanding_header.clone().into();
+        let last_state = LastState::new(last_header);
+        let prove_request = ProveRequest::new(last_state, Default::default());
+        protocol
+            .peers()
+            .mock_prove_request(peer_index, prove_request)
+            .unwrap();
+    }
+
+    let last_header = header_with_overflowing_total_difficulty(outstanding_header.clone());
+    let data = {
+        let content = packed::SendLastStateProof::new_builder()
+            .last_header(last_header)
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    }
+    .as_bytes();
+
+    protocol.received(nc.context(), peer_index, data).await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidTotalDifficulty));
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn unknown_proof() {
     let chain = MockChain::new_with_dummy_pow("test-light-client").start();


### PR DESCRIPTION
## Summary

Strengthen verifiable-header validation when handling `SendLastStateProof`, and
validate the last header before it is compared against the outstanding request.