### PR TITLE
fix: reject legacy proofs whose headers commit to uncles/extensions

### DIFF
--- a/light-client-lib/src/protocols/light_client/components/mod.rs
+++ b/light-client-lib/src/protocols/light_client/components/mod.rs
@@ -6,7 +6,9 @@ mod send_transactions_proof;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use send_blocks_proof::{verify_extra_hash, SendBlocksProofProcess};
+pub(crate) use send_blocks_proof::{
+    verify_extra_hash, verify_legacy_extra_hash, SendBlocksProofProcess,
+};
 pub(crate) use send_last_state::SendLastStateProcess;
 pub(crate) use send_last_state_proof::{verify_mmr_proof, SendLastStateProofProcess};
 pub(crate) use send_transactions_proof::SendTransactionsProofProcess;

--- a/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_blocks_proof.rs
@@ -163,6 +163,12 @@ impl<'a> SendBlocksProofProcess<'a> {
                 return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
                 extensions
             } else {
+                // A legacy (v0) response carries neither uncle hashes nor
+                // block extensions. Only accept it for headers which commit
+                // to no such data; otherwise a malicious peer could omit a
+                // CKB2023 block extension and the client would verify
+                // transactions against incomplete data.
+                return_if_failed!(verify_legacy_extra_hash(&headers));
                 vec![None; headers.len()]
             };
 
@@ -326,5 +332,28 @@ pub(crate) fn verify_extra_hash(
         }
     }
 
+    Ok(())
+}
+
+/// Verifies that headers in a legacy (v0) proof message commit to no extra
+/// data.
+///
+/// A legacy `SendBlocksProof`/`SendTransactionsProof` message carries neither
+/// uncle hashes nor block extensions. For a block without uncles and without
+/// an extension, `extra_hash` is `Byte32::zero()`; any other value commits to
+/// data the legacy message cannot provide. Accepting such a header would let
+/// a malicious peer omit a CKB2023 block extension and make the client verify
+/// transactions against incomplete data.
+pub(crate) fn verify_legacy_extra_hash(headers: &[HeaderView]) -> Result<(), Status> {
+    for header in headers {
+        if header.extra_hash() != packed::Byte32::zero() {
+            let errmsg = format!(
+                "legacy proof message omits uncle hashes/extensions committed by block#{} (hash: {:#x})",
+                header.number(),
+                header.hash(),
+            );
+            return Err(StatusCode::InvalidProof.with_context(errmsg));
+        }
+    }
     Ok(())
 }

--- a/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/send_transactions_proof.rs
@@ -7,7 +7,7 @@ use ckb_types::{
 use log::{debug, error};
 
 use crate::{
-    protocols::light_client::components::verify_extra_hash,
+    protocols::light_client::components::{verify_extra_hash, verify_legacy_extra_hash},
     storage::{HeaderWithExtension, LightClientStorage},
 };
 
@@ -168,6 +168,12 @@ impl<'a> SendTransactionsProofProcess<'a> {
                 return_if_failed!(verify_extra_hash(&headers, &uncle_hashes, &extensions));
                 extensions
             } else {
+                // A legacy (v0) response carries neither uncle hashes nor
+                // block extensions. Only accept it for headers which commit
+                // to no such data; otherwise a malicious peer could omit a
+                // CKB2023 block extension and the client would verify
+                // transactions against incomplete data.
+                return_if_failed!(verify_legacy_extra_hash(&headers));
                 vec![None; headers.len()]
             };
 

--- a/light-client-lib/src/protocols/light_client/components/tests/mod.rs
+++ b/light-client-lib/src/protocols/light_client/components/tests/mod.rs
@@ -1,1 +1,2 @@
+mod send_blocks_proof;
 mod send_last_state_proof;

--- a/light-client-lib/src/protocols/light_client/components/tests/send_blocks_proof.rs
+++ b/light-client-lib/src/protocols/light_client/components/tests/send_blocks_proof.rs
@@ -1,0 +1,51 @@
+use ckb_types::{core::BlockBuilder, packed, prelude::*};
+
+use super::super::send_blocks_proof::{verify_extra_hash, verify_legacy_extra_hash};
+
+fn extension_bytes(byte: u8) -> packed::Bytes {
+    packed::Bytes::new_builder().push(byte).build()
+}
+
+#[test]
+fn verify_legacy_extra_hash_accepts_blocks_without_extension() {
+    let block = BlockBuilder::default().build();
+    assert!(verify_legacy_extra_hash(&[block.header()]).is_ok());
+}
+
+#[test]
+fn verify_legacy_extra_hash_rejects_blocks_with_extension() {
+    let block = BlockBuilder::default()
+        .build()
+        .as_advanced_builder()
+        .extension(Some(extension_bytes(1)))
+        .build();
+    assert!(verify_legacy_extra_hash(&[block.header()]).is_err());
+}
+
+#[test]
+fn verify_extra_hash_accepts_matching_extension() {
+    let extension = extension_bytes(1);
+    let block = BlockBuilder::default()
+        .build()
+        .as_advanced_builder()
+        .extension(Some(extension.clone()))
+        .build();
+    let header = block.header();
+    assert!(verify_extra_hash(&[header], &[packed::Byte32::zero()], &[Some(extension)]).is_ok());
+}
+
+#[test]
+fn verify_extra_hash_rejects_mismatched_extension() {
+    let block = BlockBuilder::default()
+        .build()
+        .as_advanced_builder()
+        .extension(Some(extension_bytes(1)))
+        .build();
+    let header = block.header();
+    assert!(verify_extra_hash(
+        &[header],
+        &[packed::Byte32::zero()],
+        &[Some(extension_bytes(2))],
+    )
+    .is_err());
+}

--- a/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_blocks_proof.rs
@@ -346,10 +346,34 @@ async fn get_blocks_with_chunks() {
             let headers = headers.iter().map(|h| h.data()).collect::<Vec<_>>();
             let last_number: BlockNumber = last_header.header().raw().number().unpack();
             let proof = chain.build_proof_by_numbers(last_number, &block_numbers);
-            let content = packed::SendBlocksProof::new_builder()
+            let uncles_hashes = headers
+                .iter()
+                .map(|h| {
+                    snapshot
+                        .get_block_by_number(h.raw().number().unpack())
+                        .expect("block stored")
+                        .calc_uncles_hash()
+                })
+                .collect::<Vec<_>>();
+            let extensions = headers
+                .iter()
+                .map(|h| {
+                    packed::BytesOpt::new_builder()
+                        .set(
+                            snapshot
+                                .get_block_by_number(h.raw().number().unpack())
+                                .expect("block stored")
+                                .extension(),
+                        )
+                        .build()
+                })
+                .collect::<Vec<_>>();
+            let content = packed::SendBlocksProofV1::new_builder()
                 .last_header(last_header)
                 .proof(proof)
                 .headers(headers.pack())
+                .blocks_uncles_hash(uncles_hashes.pack())
+                .blocks_extension(extensions)
                 .build();
             packed::LightClientMessage::new_builder()
                 .set(content)
@@ -439,6 +463,57 @@ async fn empty_proof_since_all_blocks_are_missing() {
         returned_headers: block_numbers,
         missing_block_hashes: missing_block_hashes.clone(),
         returned_missing_block_hashes: missing_block_hashes,
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_proof_with_extension_block_is_rejected() {
+    // Every block mined by the mock chain carries an extension, so a legacy
+    // (v0) message which withholds the V1 fields must be rejected.
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        use_legacy_message: true,
+        expected_status: Some(StatusCode::InvalidProof),
+        ..Default::default()
+    };
+    test_send_blocks_proof(param).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v1_proof_with_incorrect_extension_is_rejected() {
+    let last_block_number = 20;
+    let block_numbers = vec![3, 5, 8, 11, 16, 18];
+    let returned_uncles_hashes = block_numbers
+        .iter()
+        .map(|_| packed::Byte32::zero())
+        .collect::<Vec<_>>();
+    // The headers commit to the real block extensions, but the message
+    // carries different extension bytes, so the V1 extra-hash verification
+    // must reject it.
+    let incorrect_extension = packed::Bytes::new_builder().push(2u8).build();
+    let returned_extensions = block_numbers
+        .iter()
+        .map(|_| {
+            packed::BytesOpt::new_builder()
+                .set(Some(incorrect_extension.clone()))
+                .build()
+        })
+        .collect::<Vec<_>>();
+    let param = TestParameter {
+        last_block_number,
+        block_numbers: block_numbers.clone(),
+        proved_block_numbers: block_numbers.clone(),
+        returned_headers: block_numbers,
+        returned_uncles_hashes: Some(returned_uncles_hashes),
+        returned_extensions: Some(returned_extensions),
+        expected_status: Some(StatusCode::InvalidProof),
         ..Default::default()
     };
     test_send_blocks_proof(param).await;
@@ -631,6 +706,8 @@ struct TestParameter {
     missing_block_hashes: Vec<packed::Byte32>,
     returned_missing_block_hashes: Vec<packed::Byte32>,
     returned_uncles_hashes: Option<Vec<packed::Byte32>>,
+    returned_extensions: Option<Vec<packed::BytesOpt>>,
+    use_legacy_message: bool,
     expected_status: Option<StatusCode>,
 }
 
@@ -711,8 +788,7 @@ async fn test_send_blocks_proof(param: TestParameter) {
         let headers = param
             .returned_headers
             .iter()
-            .map(|n| *n as BlockNumber)
-            .map(|n| snapshot.get_header_by_number(n).expect("block stored"))
+            .map(|n| snapshot.get_header_by_number(*n).expect("block stored"))
             .collect::<Vec<_>>();
         let block_hashes = headers.iter().map(|h| h.hash()).collect::<Vec<_>>().pack();
         let data = {
@@ -723,18 +799,9 @@ async fn test_send_blocks_proof(param: TestParameter) {
             if param.proved_block_numbers == all_block_numbers {
                 assert!(proof.is_empty());
             }
-            if let Some(uncles_hashes) = &param.returned_uncles_hashes {
-                let content = packed::SendBlocksProofV1::new_builder()
-                    .last_header(last_header)
-                    .proof(proof)
-                    .headers(headers.pack())
-                    .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
-                    .blocks_uncles_hash(uncles_hashes.to_owned().pack())
-                    .build();
-                packed::LightClientMessage::new_builder()
-                    .set(content)
-                    .build()
-            } else {
+            let content = if param.use_legacy_message {
+                // A legacy (v0) message which withholds the V1 fields. Only
+                // valid for blocks committing to no uncles/extensions.
                 let content = packed::SendBlocksProof::new_builder()
                     .last_header(last_header)
                     .proof(proof)
@@ -744,7 +811,62 @@ async fn test_send_blocks_proof(param: TestParameter) {
                 packed::LightClientMessage::new_builder()
                     .set(content)
                     .build()
-            }
+            } else if let Some(uncles_hashes) = &param.returned_uncles_hashes {
+                // A V1 message with explicitly crafted uncles/extensions.
+                let mut builder = packed::SendBlocksProofV1::new_builder()
+                    .last_header(last_header)
+                    .proof(proof)
+                    .headers(headers.pack())
+                    .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
+                    .blocks_uncles_hash(uncles_hashes.to_owned().pack());
+                if let Some(extensions) = &param.returned_extensions {
+                    let extensions = packed::BytesOptVec::new_builder()
+                        .set(extensions.clone())
+                        .build();
+                    builder = builder.blocks_extension(extensions);
+                }
+                let content = builder.build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            } else {
+                // A V1 message carrying the real uncles hashes and extensions
+                // from the snapshot, like an honest server would send.
+                let uncles_hashes = headers
+                    .iter()
+                    .map(|h| {
+                        snapshot
+                            .get_block_by_number(h.raw().number().unpack())
+                            .expect("block stored")
+                            .calc_uncles_hash()
+                    })
+                    .collect::<Vec<_>>();
+                let extensions = headers
+                    .iter()
+                    .map(|h| {
+                        packed::BytesOpt::new_builder()
+                            .set(
+                                snapshot
+                                    .get_block_by_number(h.raw().number().unpack())
+                                    .expect("block stored")
+                                    .extension(),
+                            )
+                            .build()
+                    })
+                    .collect::<Vec<_>>();
+                let content = packed::SendBlocksProofV1::new_builder()
+                    .last_header(last_header)
+                    .proof(proof)
+                    .headers(headers.pack())
+                    .missing_block_hashes(param.returned_missing_block_hashes.clone().pack())
+                    .blocks_uncles_hash(uncles_hashes.pack())
+                    .blocks_extension(extensions)
+                    .build();
+                packed::LightClientMessage::new_builder()
+                    .set(content)
+                    .build()
+            };
+            content
         }
         .as_bytes();
 

--- a/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
+++ b/light-client-lib/src/tests/protocols/light_client/send_transactions_proof.rs
@@ -98,14 +98,39 @@ async fn test_send_txs_proof_ok() {
             let last_number = last_header.header().raw().number().unpack();
             chain.build_proof_by_numbers(last_number, &block_numbers)
         };
+        let snapshot = chain.shared().snapshot();
+        let uncles_hashes = block_numbers
+            .iter()
+            .map(|n| {
+                snapshot
+                    .get_block_by_number(*n)
+                    .expect("block stored")
+                    .calc_uncles_hash()
+            })
+            .collect::<Vec<_>>();
+        let extensions = block_numbers
+            .iter()
+            .map(|n| {
+                packed::BytesOpt::new_builder()
+                    .set(
+                        snapshot
+                            .get_block_by_number(*n)
+                            .expect("block stored")
+                            .extension(),
+                    )
+                    .build()
+            })
+            .collect::<Vec<_>>();
         let items = packed::FilteredBlockVec::new_builder()
             .set(filtered_blocks)
             .build();
-        let content = packed::SendTransactionsProof::new_builder()
+        let content = packed::SendTransactionsProofV1::new_builder()
             .last_header(last_header.clone())
             .proof(proof.pack())
             .filtered_blocks(items)
             .missing_tx_hashes(missing_tx_hashes.clone().pack())
+            .blocks_uncles_hash(uncles_hashes.pack())
+            .blocks_extension(extensions)
             .build();
         packed::LightClientMessage::new_builder()
             .set(content)
@@ -236,13 +261,38 @@ async fn test_send_txs_proof_invalid_mmr_proof() {
             // NOTE: this is invalid mmr proof
             chain.build_proof_by_numbers(last_number, &block_numbers[0..block_numbers.len() - 1])
         };
+        let snapshot = chain.shared().snapshot();
+        let uncles_hashes = block_numbers
+            .iter()
+            .map(|n| {
+                snapshot
+                    .get_block_by_number(*n)
+                    .expect("block stored")
+                    .calc_uncles_hash()
+            })
+            .collect::<Vec<_>>();
+        let extensions = block_numbers
+            .iter()
+            .map(|n| {
+                packed::BytesOpt::new_builder()
+                    .set(
+                        snapshot
+                            .get_block_by_number(*n)
+                            .expect("block stored")
+                            .extension(),
+                    )
+                    .build()
+            })
+            .collect::<Vec<_>>();
         let items = packed::FilteredBlockVec::new_builder()
             .set(filtered_blocks)
             .build();
-        let content = packed::SendTransactionsProof::new_builder()
+        let content = packed::SendTransactionsProofV1::new_builder()
             .last_header(last_header.clone())
             .proof(proof.pack())
             .filtered_blocks(items)
+            .blocks_uncles_hash(uncles_hashes.pack())
+            .blocks_extension(extensions)
             .build();
         packed::LightClientMessage::new_builder()
             .set(content)
@@ -366,13 +416,38 @@ async fn test_send_txs_proof_invalid_merkle_proof() {
             let last_number = last_header.header().raw().number().unpack();
             chain.build_proof_by_numbers(last_number, &block_numbers)
         };
+        let snapshot = chain.shared().snapshot();
+        let uncles_hashes = block_numbers
+            .iter()
+            .map(|n| {
+                snapshot
+                    .get_block_by_number(*n)
+                    .expect("block stored")
+                    .calc_uncles_hash()
+            })
+            .collect::<Vec<_>>();
+        let extensions = block_numbers
+            .iter()
+            .map(|n| {
+                packed::BytesOpt::new_builder()
+                    .set(
+                        snapshot
+                            .get_block_by_number(*n)
+                            .expect("block stored")
+                            .extension(),
+                    )
+                    .build()
+            })
+            .collect::<Vec<_>>();
         let items = packed::FilteredBlockVec::new_builder()
             .set(filtered_blocks)
             .build();
-        let content = packed::SendTransactionsProof::new_builder()
+        let content = packed::SendTransactionsProofV1::new_builder()
             .last_header(last_header.clone())
             .proof(proof.pack())
             .filtered_blocks(items)
+            .blocks_uncles_hash(uncles_hashes.pack())
+            .blocks_extension(extensions)
             .build();
         packed::LightClientMessage::new_builder()
             .set(content)
@@ -410,6 +485,113 @@ async fn test_send_txs_proof_invalid_merkle_proof() {
             .get_transaction_with_header(&tx_hash)
             .is_none());
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_txs_proof_for_extension_block_is_rejected() {
+    let chain = MockChain::new_with_dummy_pow("test-send-txs-legacy-ext").start();
+    let nc = MockNetworkContext::new(SupportProtocols::LightClient);
+    let peer_index = PeerIndex::new(3);
+
+    chain.mine_to(20);
+    let tx = chain.get_cellbase_as_input(13);
+    chain.mine_block(|block| {
+        let ids = vec![tx.proposal_short_id()];
+        block.as_advanced_builder().proposals(ids).build()
+    });
+    chain.mine_blocks(1);
+    chain.mine_block(|block| block.as_advanced_builder().transaction(tx.clone()).build());
+    chain.mine_blocks(1);
+
+    let tx_hash = tx.hash();
+    let (tx, tx_info) = chain
+        .shared()
+        .snapshot()
+        .get_transaction_with_info(&tx_hash)
+        .unwrap();
+    let block = chain
+        .shared()
+        .snapshot()
+        .get_block(&tx_info.block_hash)
+        .unwrap();
+    let block_number = block.number();
+    let witnesses_root = block.calc_witnesses_root();
+
+    // Every block mined by the mock chain carries an extension, so a legacy
+    // (v0) message which withholds the V1 fields must be rejected.
+    let header = block.header();
+
+    let merkle_proof = CBMT::build_merkle_proof(
+        &block
+            .transactions()
+            .iter()
+            .map(|tx| tx.hash())
+            .collect::<Vec<_>>(),
+        &[tx_info.index as u32],
+    )
+    .unwrap();
+    let filtered_block = packed::FilteredBlock::new_builder()
+        .header(header.data())
+        .witnesses_root(witnesses_root)
+        .transactions(vec![tx.data()].pack())
+        .proof(
+            packed::MerkleProof::new_builder()
+                .indices(merkle_proof.indices().to_owned().pack())
+                .lemmas(merkle_proof.lemmas().to_owned().pack())
+                .build(),
+        )
+        .build();
+
+    let last_header = chain
+        .shared()
+        .snapshot()
+        .get_verifiable_header_by_number(block_number + 1)
+        .unwrap();
+    let message = {
+        let proof = {
+            let last_number = last_header.header().raw().number().unpack();
+            chain.build_proof_by_numbers(last_number, &[block_number])
+        };
+        let items = packed::FilteredBlockVec::new_builder()
+            .set(vec![filtered_block])
+            .build();
+        let content = packed::SendTransactionsProof::new_builder()
+            .last_header(last_header.clone())
+            .proof(proof.pack())
+            .filtered_blocks(items)
+            .build();
+        packed::LightClientMessage::new_builder()
+            .set(content)
+            .build()
+    };
+
+    let peers = {
+        let peers = chain.create_peers();
+        let txs_proof_request = packed::GetTransactionsProof::new_builder()
+            .last_hash(last_header.header().calc_header_hash())
+            .tx_hashes(vec![tx_hash.clone()].pack())
+            .build();
+        peers.add_peer(peer_index);
+        peers
+            .mock_prove_state(peer_index, last_header.into())
+            .unwrap();
+        peers.update_txs_proof_request(peer_index, Some(txs_proof_request));
+        peers
+    };
+
+    peers.add_fetch_tx(tx_hash.clone(), 111);
+
+    let mut protocol = chain.create_light_client_protocol(Arc::clone(&peers));
+    protocol
+        .received(nc.context(), peer_index, message.as_bytes())
+        .await;
+
+    assert!(nc.banned_since(peer_index, StatusCode::InvalidProof));
+    assert!(nc.sent_messages().borrow().is_empty());
+    assert!(chain
+        .client_storage()
+        .get_transaction_with_header(&tx_hash)
+        .is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Problem

A peer can answer a `GetBlocksProof` / `GetTransactionsProof` request with a legacy (v0) message that omits the V1 extra fields (`blocks_uncles_hash`, `blocks_extension`). The client fabricated `None` extensions for every proved header without checking whether the header's authenticated `extra_hash` actually commits to an empty uncle list and no extension. Stored headers then served `None` from `ExtensionProvider`, so scripts using the CKB2023 `load_extension` syscall were evaluated against missing extension data and local verification diverged from consensus.

Refs: sec-reports `PENDING-HIGH-0007` ("Peer can omit CKB2023 block extensions").

## Fix

For a block without uncles and without an extension, `extra_hash` is `Byte32::zero()` (the empty uncles hash is zero, and `extra_hash` equals the uncles hash when no extension is committed). Any other value commits to data the legacy message cannot carry.

- `send_blocks_proof.rs`: new `verify_legacy_extra_hash()` helper, called in the legacy branch before the MMR proof.
- `send_transactions_proof.rs`: same check in its legacy branch.
- Rejection returns `InvalidProof` (439), which is ban-eligible through the existing misbehavior rate limiter.

## Compatibility

- Legacy (v0) responses remain accepted for blocks with no uncles and no extension (e.g. pre-V1 servers still work for those blocks).
- Blocks with uncles and/or extensions now require the V1 fields — which the client needs anyway, since it cannot reconstruct uncle hashes or extensions from a legacy message.

## Tests

- Unit tests for `verify_legacy_extra_hash` and `verify_extra_hash` (accept/reject cases).
- Integration: legacy blocks proof and legacy transactions proof for extension-bearing blocks are rejected; V1 proof with an incorrect extension is rejected.
- The mock chain's block assembler attaches an extension to every mined block, so the proof-message test harness and the three tx-proof tests now send V1 messages carrying the real uncle hashes and extensions, like an honest server would.
- Full `ckb-light-client-lib` suite: 122/122 pass. `ckb-light-client` bin compiles; clippy clean for the changed code.