### PR TITLE
fix: normalize peer checkpoints before quorum check

### DIFF
--- a/light-client-lib/src/protocols/filter/mod.rs
+++ b/light-client-lib/src/protocols/filter/mod.rs
@@ -8,4 +8,4 @@ const BAD_MESSAGE_BAN_TIME: Duration = Duration::from_secs(5 * 60);
 pub use block_filter::FilterProtocol;
 
 #[cfg(test)]
-pub(crate) use block_filter::GET_BLOCK_FILTERS_TOKEN;
+pub(crate) use block_filter::{GET_BLOCK_FILTERS_TOKEN, GET_BLOCK_FILTER_HASHES_TOKEN};

--- a/light-client-lib/src/protocols/light_client/mod.rs
+++ b/light-client-lib/src/protocols/light_client/mod.rs
@@ -536,27 +536,15 @@ impl LightClientProtocol {
             }
         }
 
-        if peers_with_data.len() < required_peers_count {
-            debug!(
-                "no enough peers for finalizing check points, \
-                requires {} but got {}",
-                required_peers_count,
-                peers_with_data.len()
-            );
-            return;
-        }
-        trace!(
-            "requires {} peers for finalizing check points and got {}",
-            required_peers_count,
-            peers_with_data.len()
-        );
         let (last_cpindex, last_check_point) = self.storage.get_last_check_point();
         trace!(
             "finalized check point is {}, {:#x}",
             last_cpindex,
             last_check_point
         );
-        // Clean finalized check points for new proved peers.
+        // Normalizing peers against an already finalized local check point does not require a
+        // quorum. Do it before checking the peer count so a quorum loss cannot leave stale start
+        // indexes that prevent block filter hash requests.
         {
             let mut peers_should_be_skipped = Vec::new();
             for (peer_index, (start_cpindex, check_points)) in peers_with_data.iter_mut() {
@@ -610,7 +598,7 @@ impl LightClientProtocol {
             }
         }
         if peers_with_data.len() < required_peers_count {
-            trace!(
+            debug!(
                 "no enough peers for finalizing check points after cleaning, \
                 requires {} but got {}",
                 required_peers_count,
@@ -618,6 +606,11 @@ impl LightClientProtocol {
             );
             return;
         }
+        trace!(
+            "requires {} peers for finalizing check points and got {}",
+            required_peers_count,
+            peers_with_data.len()
+        );
         // Find a new check point to finalized.
         let check_point_opt =
             {

--- a/light-client-lib/src/protocols/mod.rs
+++ b/light-client-lib/src/protocols/mod.rs
@@ -11,7 +11,7 @@ mod relayer;
 mod synchronizer;
 
 #[cfg(test)]
-pub(crate) use filter::GET_BLOCK_FILTERS_TOKEN;
+pub(crate) use filter::{GET_BLOCK_FILTERS_TOKEN, GET_BLOCK_FILTER_HASHES_TOKEN};
 
 pub use light_client::{FetchInfo, LastState, PeerState, ProveRequest, ProveState};
 

--- a/light-client-lib/src/tests/protocols/block_filter.rs
+++ b/light-client-lib/src/tests/protocols/block_filter.rs
@@ -15,7 +15,10 @@ use ckb_types::{
 use crate::storage::{LightClientStorage, SetScriptsCommand};
 use crate::storage::{ScriptStatus, ScriptType};
 use crate::{
-    protocols::{BAD_MESSAGE_BAN_TIME, GET_BLOCK_FILTERS_TOKEN},
+    protocols::{
+        light_client::constant::REFRESH_PEERS_TOKEN, BAD_MESSAGE_BAN_TIME, CHECK_POINT_INTERVAL,
+        GET_BLOCK_FILTERS_TOKEN, GET_BLOCK_FILTER_HASHES_TOKEN,
+    },
     tests::{
         prelude::*,
         utils::{setup, MockChain, MockNetworkContext},
@@ -526,6 +529,81 @@ async fn test_block_filter_notify_ask_filters() {
             message.as_bytes()
         )]
     );
+}
+
+#[tokio::test]
+async fn test_filter_hash_request_after_checkpoint_quorum_loss() {
+    let chain = MockChain::new_with_dummy_pow("test-block-filter");
+    let light_client_network_context = MockNetworkContext::new(SupportProtocols::LightClient);
+    let filter_network_context = MockNetworkContext::new(SupportProtocols::Filter);
+
+    let storage = chain.client_storage();
+    let (initial_check_point_index, initial_check_point) = storage.get_last_check_point();
+    assert_eq!(initial_check_point_index, 0);
+
+    let next_check_point = H256(rand::random()).pack();
+    let proved_number = CHECK_POINT_INTERVAL * 2;
+    let tip_header = VerifiableHeader::new(
+        HeaderBuilder::default()
+            .epoch(EpochNumberWithFraction::new(0, 0, 100).full_value())
+            .number(proved_number)
+            .build(),
+        Default::default(),
+        None,
+        Default::default(),
+    );
+    let peer_indexes = (1..=4).map(PeerIndex::new).collect::<Vec<_>>();
+    let peers = chain.create_peers();
+    peers.set_max_outbound_peers(8);
+    for peer_index in &peer_indexes {
+        peers.add_peer(*peer_index);
+        peers
+            .mock_prove_state(*peer_index, tip_header.clone())
+            .unwrap();
+        let next_start_number = peers
+            .add_check_points(
+                *peer_index,
+                proved_number,
+                0,
+                &[initial_check_point.clone(), next_check_point.clone()],
+            )
+            .unwrap();
+        assert!(next_start_number.is_none());
+    }
+
+    let mut light_client_protocol = chain.create_light_client_protocol(Arc::clone(&peers));
+    light_client_protocol
+        .notify(light_client_network_context.context(), REFRESH_PEERS_TOKEN)
+        .await;
+    assert_eq!(storage.get_last_check_point(), (1, next_check_point));
+
+    peers.remove_peer(peer_indexes[3]).await;
+    light_client_protocol
+        .notify(light_client_network_context.context(), REFRESH_PEERS_TOKEN)
+        .await;
+
+    let mut filter_protocol = chain.create_filter_protocol(peers);
+    filter_protocol
+        .notify(
+            filter_network_context.context(),
+            GET_BLOCK_FILTER_HASHES_TOKEN,
+        )
+        .await;
+
+    let expected_message = packed::BlockFilterMessage::new_builder()
+        .set(
+            packed::GetBlockFilterHashes::new_builder()
+                .start_number(1u64)
+                .build(),
+        )
+        .build()
+        .as_bytes();
+    let sent_messages = filter_network_context.sent_messages().borrow();
+    assert_eq!(sent_messages.len(), 1);
+    let (protocol_id, peer_index, message) = &sent_messages[0];
+    assert_eq!(*protocol_id, SupportProtocols::Filter.protocol_id());
+    assert!(peer_indexes[..3].contains(peer_index));
+    assert_eq!(message, &expected_message);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- normalize proved peer checkpoint ranges against the locally finalized checkpoint before checking quorum
- preserve the configured quorum requirement for finalizing new checkpoints
- add a regression test covering quorum loss after checkpoint finalization

## Root cause

After a checkpoint advanced, peer ranges could remain anchored at the previous checkpoint. If the proved peer count then fell below quorum, `finalize_check_points` returned before normalizing those ranges. The block-filter-hash requester rejected every peer whose start index lagged the finalized index, leaving cached hashes empty and filter synchronization stuck.

The fix performs validation and normalization against the already trusted local checkpoint regardless of peer count. Invalid peers are still rejected or banned, while advancing to any new finalized checkpoint still requires quorum.

## Tests

- `CFLAGS=-O1 make test` — 125 passed
- `make fmt`
- `cargo clippy --target wasm32-unknown-unknown -p light-client-wasm -p ckb-light-client-lib -p light-client-db-common -p light-client-db-worker --locked -- --deny warnings`
- `cargo clippy -p ckb-light-client-lib --lib --locked -- --deny warnings`
- `CFLAGS=-O1 cargo clippy -p ckb-light-client --locked -- --deny warnings`

`CFLAGS=-O1` is only needed in the local Nix environment to avoid a jemalloc configure probe failure caused by `_FORTIFY_SOURCE` with debug `-O0`.